### PR TITLE
#17 CLI interface implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <artifactId>gson</artifactId>
             <version>2.11.0</version>
         </dependency>
+        
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.9.0</version>
+        </dependency>
     </dependencies>
     
     <build>
@@ -138,6 +144,28 @@
                                     </limits>
                                 </rule>
                             </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.example.linter.cli.LinterCLI</mainClass>
+                                </transformer>
+                            </transformers>
+                            <finalName>power-adoc-linter</finalName>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/example/linter/Linter.java
+++ b/src/main/java/com/example/linter/Linter.java
@@ -1,0 +1,250 @@
+package com.example.linter;
+
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.rule.SectionConfig;
+import com.example.linter.validator.*;
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.ast.StructuralNode;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+
+/**
+ * Main entry point for the AsciiDoc linter.
+ * Provides methods to validate AsciiDoc files against a configuration.
+ */
+public class Linter {
+    
+    private final Asciidoctor asciidoctor;
+    
+    public Linter() {
+        this.asciidoctor = Asciidoctor.Factory.create();
+    }
+    
+    /**
+     * Validates a single AsciiDoc file.
+     * 
+     * @param file the file to validate
+     * @param config the linter configuration
+     * @return validation result
+     * @throws IOException if the file cannot be read
+     */
+    public ValidationResult validateFile(Path file, LinterConfiguration config) throws IOException {
+        Objects.requireNonNull(file, "file must not be null");
+        Objects.requireNonNull(config, "config must not be null");
+        
+        if (!Files.exists(file)) {
+            throw new IOException("File does not exist: " + file);
+        }
+        
+        if (!Files.isRegularFile(file)) {
+            throw new IOException("Not a regular file: " + file);
+        }
+        
+        return performValidation(file, config);
+    }
+    
+    /**
+     * Validates multiple AsciiDoc files.
+     * 
+     * @param files the files to validate
+     * @param config the linter configuration
+     * @return map of file to validation result
+     */
+    public Map<Path, ValidationResult> validateFiles(List<Path> files, LinterConfiguration config) {
+        Objects.requireNonNull(files, "files must not be null");
+        Objects.requireNonNull(config, "config must not be null");
+        
+        Map<Path, ValidationResult> results = new LinkedHashMap<>();
+        
+        for (Path file : files) {
+            try {
+                ValidationResult result = validateFile(file, config);
+                results.put(file, result);
+            } catch (IOException e) {
+                // Create error result
+                ValidationResult errorResult = createIOErrorResult(file, e);
+                results.put(file, errorResult);
+            }
+        }
+        
+        return results;
+    }
+    
+    /**
+     * Validates all matching files in a directory.
+     * 
+     * @param directory the directory to scan
+     * @param pattern file pattern (e.g., "*.adoc")
+     * @param recursive whether to scan subdirectories
+     * @param config the linter configuration
+     * @return map of file to validation result
+     * @throws IOException if the directory cannot be read
+     */
+    public Map<Path, ValidationResult> validateDirectory(Path directory, String pattern, 
+                                                       boolean recursive, LinterConfiguration config) throws IOException {
+        Objects.requireNonNull(directory, "directory must not be null");
+        Objects.requireNonNull(pattern, "pattern must not be null");
+        Objects.requireNonNull(config, "config must not be null");
+        
+        if (!Files.isDirectory(directory)) {
+            throw new IOException("Not a directory: " + directory);
+        }
+        
+        List<Path> files = findMatchingFiles(directory, pattern, recursive);
+        return validateFiles(files, config);
+    }
+    
+    /**
+     * Closes the linter and releases resources.
+     */
+    public void close() {
+        if (asciidoctor != null) {
+            asciidoctor.close();
+        }
+    }
+    
+    private ValidationResult performValidation(Path file, LinterConfiguration config) {
+        ValidationResult.Builder resultBuilder = ValidationResult.builder();
+        
+        try {
+            // Parse the document
+            Document document = asciidoctor.loadFile(file.toFile(), Map.of());
+            
+            // Run validators
+            List<ValidationMessage> messages = new ArrayList<>();
+            
+            if (config.document() != null) {
+                // Metadata validation
+                if (config.document().metadata() != null) {
+                    MetadataValidator metadataValidator = MetadataValidator.builder()
+                        .configuration(config.document().metadata())
+                        .build();
+                    ValidationResult metadataResult = metadataValidator.validate(document);
+                    messages.addAll(metadataResult.getMessages());
+                }
+                
+                // Section validation
+                if (config.document().sections() != null) {
+                    SectionValidator sectionValidator = SectionValidator.builder()
+                        .configuration(config.document())
+                        .build();
+                    ValidationResult sectionResult = sectionValidator.validate(document);
+                    messages.addAll(sectionResult.getMessages());
+                    
+                    // Block validation within sections
+                    messages.addAll(validateBlocks(document, config.document().sections()));
+                }
+            }
+            
+            // Add all messages to result
+            messages.forEach(resultBuilder::addMessage);
+            
+        } catch (Exception e) {
+            // Add error message for parsing failure
+            resultBuilder.addMessage(createParseErrorMessage(file, e));
+        }
+        
+        return resultBuilder.complete().build();
+    }
+    
+    private List<ValidationMessage> validateBlocks(Document document, List<SectionConfig> sectionConfigs) {
+        List<ValidationMessage> messages = new ArrayList<>();
+        BlockValidator blockValidator = new BlockValidator();
+        String filename = extractDocumentFilename(document);
+        
+        // Validate blocks in each section
+        for (StructuralNode node : document.getBlocks()) {
+            if (node instanceof org.asciidoctor.ast.Section) {
+                org.asciidoctor.ast.Section section = (org.asciidoctor.ast.Section) node;
+                
+                // Find matching section config
+                for (SectionConfig sectionConfig : sectionConfigs) {
+                    if (matchesSection(section, sectionConfig)) {
+                        ValidationResult blockResult = blockValidator.validate(section, sectionConfig, filename);
+                        messages.addAll(blockResult.getMessages());
+                        break;
+                    }
+                }
+            }
+        }
+        
+        return messages;
+    }
+    
+    private List<Path> findMatchingFiles(Path directory, String pattern, boolean recursive) throws IOException {
+        List<Path> matchingFiles = new ArrayList<>();
+        PathMatcher pathMatcher = directory.getFileSystem().getPathMatcher("glob:" + pattern);
+        int maxDepth = recursive ? Integer.MAX_VALUE : 1;
+        
+        Files.walkFileTree(directory, new HashSet<>(), maxDepth, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (pathMatcher.matches(file.getFileName())) {
+                    matchingFiles.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+            
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                // Log warning but continue
+                System.err.println("Warning: Could not access file: " + file + " (" + exc.getMessage() + ")");
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        
+        return matchingFiles;
+    }
+    
+    private String extractDocumentFilename(Document document) {
+        Map<String, Object> attrs = document.getAttributes();
+        if (attrs.containsKey("docfile")) {
+            return attrs.get("docfile").toString();
+        }
+        return "unknown";
+    }
+    
+    private boolean matchesSection(org.asciidoctor.ast.Section section, SectionConfig config) {
+        // Match by title pattern if configured
+        if (config.title() != null && config.title().pattern() != null) {
+            String title = section.getTitle();
+            if (title != null) {
+                return title.matches(config.title().pattern());
+            }
+        }
+        
+        // Match by level
+        return config.level() == section.getLevel();
+    }
+    
+    private ValidationResult createIOErrorResult(Path file, IOException e) {
+        return ValidationResult.builder()
+            .addMessage(ValidationMessage.builder()
+                .severity(com.example.linter.config.Severity.ERROR)
+                .ruleId("io-error")
+                .location(SourceLocation.builder()
+                    .filename(file.toString())
+                    .startLine(1)
+                    .build())
+                .message("I/O error: " + e.getMessage())
+                .build())
+            .complete()
+            .build();
+    }
+    
+    private ValidationMessage createParseErrorMessage(Path file, Exception e) {
+        return ValidationMessage.builder()
+            .severity(com.example.linter.config.Severity.ERROR)
+            .ruleId("parse-error")
+            .location(SourceLocation.builder()
+                .filename(file.toString())
+                .startLine(1)
+                .build())
+            .message("Failed to parse AsciiDoc file: " + e.getMessage())
+            .build();
+    }
+}

--- a/src/main/java/com/example/linter/cli/CLIConfig.java
+++ b/src/main/java/com/example/linter/cli/CLIConfig.java
@@ -1,0 +1,115 @@
+package com.example.linter.cli;
+
+import com.example.linter.config.Severity;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Configuration object containing parsed CLI arguments.
+ */
+public class CLIConfig {
+    
+    private final Path input;
+    private final Path configFile;
+    private final String reportFormat;
+    private final Path reportOutput;
+    private final boolean recursive;
+    private final String pattern;
+    private final Severity failLevel;
+    
+    private CLIConfig(Builder builder) {
+        this.input = Objects.requireNonNull(builder.input, "input must not be null");
+        this.configFile = builder.configFile;
+        this.reportFormat = Objects.requireNonNull(builder.reportFormat, "reportFormat must not be null");
+        this.reportOutput = builder.reportOutput;
+        this.recursive = builder.recursive;
+        this.pattern = Objects.requireNonNull(builder.pattern, "pattern must not be null");
+        this.failLevel = Objects.requireNonNull(builder.failLevel, "failLevel must not be null");
+    }
+    
+    public Path getInput() {
+        return input;
+    }
+    
+    public Path getConfigFile() {
+        return configFile;
+    }
+    
+    public String getReportFormat() {
+        return reportFormat;
+    }
+    
+    public Path getReportOutput() {
+        return reportOutput;
+    }
+    
+    public boolean isRecursive() {
+        return recursive;
+    }
+    
+    public String getPattern() {
+        return pattern;
+    }
+    
+    public Severity getFailLevel() {
+        return failLevel;
+    }
+    
+    public boolean isOutputToFile() {
+        return reportOutput != null;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static class Builder {
+        private Path input;
+        private Path configFile;
+        private String reportFormat = "console";
+        private Path reportOutput;
+        private boolean recursive = true;
+        private String pattern = "*.adoc";
+        private Severity failLevel = Severity.ERROR;
+        
+        public Builder input(Path input) {
+            this.input = input;
+            return this;
+        }
+        
+        public Builder configFile(Path configFile) {
+            this.configFile = configFile;
+            return this;
+        }
+        
+        public Builder reportFormat(String reportFormat) {
+            this.reportFormat = reportFormat;
+            return this;
+        }
+        
+        public Builder reportOutput(Path reportOutput) {
+            this.reportOutput = reportOutput;
+            return this;
+        }
+        
+        public Builder recursive(boolean recursive) {
+            this.recursive = recursive;
+            return this;
+        }
+        
+        public Builder pattern(String pattern) {
+            this.pattern = pattern;
+            return this;
+        }
+        
+        public Builder failLevel(Severity failLevel) {
+            this.failLevel = failLevel;
+            return this;
+        }
+        
+        public CLIConfig build() {
+            return new CLIConfig(this);
+        }
+    }
+}

--- a/src/main/java/com/example/linter/cli/CLIOptions.java
+++ b/src/main/java/com/example/linter/cli/CLIOptions.java
@@ -1,0 +1,96 @@
+package com.example.linter.cli;
+
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+/**
+ * Defines command line options for the AsciiDoc linter CLI.
+ */
+public class CLIOptions {
+    
+    private final Options options;
+    
+    public CLIOptions() {
+        this.options = new Options();
+        defineOptions();
+    }
+    
+    private void defineOptions() {
+        // Input file/directory (required)
+        options.addOption(Option.builder("i")
+            .longOpt("input")
+            .hasArg()
+            .argName("file/directory")
+            .desc("AsciiDoc file or directory to validate")
+            .required()
+            .build());
+        
+        // Configuration file
+        options.addOption(Option.builder("c")
+            .longOpt("config")
+            .hasArg()
+            .argName("file")
+            .desc("YAML configuration file (default: .linter-config.yaml)")
+            .build());
+        
+        // Report format
+        options.addOption(Option.builder("f")
+            .longOpt("report-format")
+            .hasArg()
+            .argName("format")
+            .desc("Report format: console, json (default: console)")
+            .build());
+        
+        // Report output
+        options.addOption(Option.builder("o")
+            .longOpt("report-output")
+            .hasArg()
+            .argName("file/directory")
+            .desc("Report output file or directory (default: stdout)")
+            .build());
+        
+        // Recursive
+        options.addOption(Option.builder("r")
+            .longOpt("recursive")
+            .desc("Recursively scan directories (default: true)")
+            .build());
+        
+        // No recursive
+        options.addOption(Option.builder()
+            .longOpt("no-recursive")
+            .desc("Do not scan directories recursively")
+            .build());
+        
+        // Pattern
+        options.addOption(Option.builder("p")
+            .longOpt("pattern")
+            .hasArg()
+            .argName("glob")
+            .desc("File pattern glob (default: *.adoc)")
+            .build());
+        
+        // Fail level
+        options.addOption(Option.builder("l")
+            .longOpt("fail-level")
+            .hasArg()
+            .argName("level")
+            .desc("Exit code 1 on: error, warn, info (default: error)")
+            .build());
+        
+        // Help
+        options.addOption(Option.builder("h")
+            .longOpt("help")
+            .desc("Show help message")
+            .build());
+        
+        // Version
+        options.addOption(Option.builder("v")
+            .longOpt("version")
+            .desc("Show version")
+            .build());
+    }
+    
+    public Options getOptions() {
+        return options;
+    }
+}

--- a/src/main/java/com/example/linter/cli/CLIOutputHandler.java
+++ b/src/main/java/com/example/linter/cli/CLIOutputHandler.java
@@ -1,0 +1,104 @@
+package com.example.linter.cli;
+
+import com.example.linter.report.ReportWriter;
+import com.example.linter.validator.ValidationResult;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Handles output routing for CLI based on configuration.
+ */
+public class CLIOutputHandler {
+    
+    private final ReportWriter reportWriter;
+    
+    public CLIOutputHandler() {
+        this.reportWriter = new ReportWriter();
+    }
+    
+    /**
+     * Writes a single validation result based on the CLI configuration.
+     */
+    public void writeReport(ValidationResult result, CLIConfig config) throws IOException {
+        if (config.isOutputToFile()) {
+            // Write to file
+            Path outputFile = config.getReportOutput();
+            ensureParentDirectoryExists(outputFile);
+            
+            try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile.toFile()))) {
+                reportWriter.write(result, config.getReportFormat(), writer);
+            }
+        } else {
+            // Write to console (stdout)
+            reportWriter.writeToConsole(result, config.getReportFormat());
+        }
+    }
+    
+    /**
+     * Writes multiple validation results for directory input.
+     */
+    public void writeMultipleReports(Map<Path, ValidationResult> results, CLIConfig config, 
+                                   ValidationResult aggregated) throws IOException {
+        if (!config.isOutputToFile()) {
+            // Write aggregated result to console
+            reportWriter.writeToConsole(aggregated, config.getReportFormat());
+            return;
+        }
+        
+        Path output = config.getReportOutput();
+        
+        if (Files.isDirectory(output) || output.toString().endsWith("/") || output.toString().endsWith("\\")) {
+            // Write individual reports to directory
+            writeIndividualReports(results, config, output);
+        } else {
+            // Write aggregated report to single file
+            writeReport(aggregated, config);
+        }
+    }
+    
+    private void writeIndividualReports(Map<Path, ValidationResult> results, CLIConfig config, 
+                                      Path outputDir) throws IOException {
+        // Ensure output directory exists
+        if (!Files.exists(outputDir)) {
+            Files.createDirectories(outputDir);
+        }
+        
+        for (Map.Entry<Path, ValidationResult> entry : results.entrySet()) {
+            Path inputFile = entry.getKey();
+            ValidationResult result = entry.getValue();
+            
+            // Generate output filename based on input filename
+            String outputFileName = generateOutputFileName(inputFile, config.getReportFormat());
+            Path outputFile = outputDir.resolve(outputFileName);
+            
+            try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile.toFile()))) {
+                reportWriter.write(result, config.getReportFormat(), writer);
+            }
+        }
+    }
+    
+    private String generateOutputFileName(Path inputFile, String format) {
+        String baseName = inputFile.getFileName().toString();
+        
+        // Remove .adoc extension if present
+        if (baseName.endsWith(".adoc")) {
+            baseName = baseName.substring(0, baseName.length() - 5);
+        }
+        
+        // Add format extension
+        String extension = "json".equals(format) ? ".json" : ".txt";
+        return baseName + "-report" + extension;
+    }
+    
+    private void ensureParentDirectoryExists(Path file) throws IOException {
+        Path parent = file.getParent();
+        if (parent != null && !Files.exists(parent)) {
+            Files.createDirectories(parent);
+        }
+    }
+}

--- a/src/main/java/com/example/linter/cli/CLIRunner.java
+++ b/src/main/java/com/example/linter/cli/CLIRunner.java
@@ -1,0 +1,131 @@
+package com.example.linter.cli;
+
+import com.example.linter.Linter;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.loader.ConfigurationLoader;
+import com.example.linter.validator.ValidationMessage;
+import com.example.linter.validator.ValidationResult;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Executes the linter based on CLI configuration.
+ */
+public class CLIRunner {
+    
+    private static final String DEFAULT_CONFIG_FILE = ".linter-config.yaml";
+    
+    private final FileDiscoveryService fileDiscoveryService;
+    private final CLIOutputHandler outputHandler;
+    private final ConfigurationLoader configurationLoader;
+    private final Linter linter;
+    
+    public CLIRunner() {
+        this.fileDiscoveryService = new FileDiscoveryService();
+        this.outputHandler = new CLIOutputHandler();
+        this.configurationLoader = new ConfigurationLoader();
+        this.linter = new Linter();
+    }
+    
+    /**
+     * Runs the linter with the given configuration.
+     * 
+     * @param config CLI configuration
+     * @return Exit code (0 = success, 1 = violations, 2 = error)
+     */
+    public int run(CLIConfig config) {
+        try {
+            // Load linter configuration
+            LinterConfiguration linterConfig = loadLinterConfiguration(config);
+            
+            // Discover files
+            List<Path> filesToValidate = fileDiscoveryService.discoverFiles(config);
+            
+            if (filesToValidate.isEmpty()) {
+                System.err.println("No files found matching pattern: " + config.getPattern());
+                return 2;
+            }
+            
+            // Print files being validated
+            if (filesToValidate.size() > 1) {
+                System.err.println("Validating " + filesToValidate.size() + " files...");
+            }
+            
+            // Validate files
+            if (filesToValidate.size() == 1) {
+                // Single file validation
+                ValidationResult result = linter.validateFile(filesToValidate.get(0), linterConfig);
+                outputHandler.writeReport(result, config);
+                return determineExitCode(result, config.getFailLevel());
+            } else {
+                // Multiple file validation
+                Map<Path, ValidationResult> results = linter.validateFiles(filesToValidate, linterConfig);
+                ValidationResult aggregated = aggregateResults(results);
+                outputHandler.writeMultipleReports(results, config, aggregated);
+                return determineExitCode(aggregated, config.getFailLevel());
+            }
+            
+        } catch (IOException e) {
+            System.err.println("I/O error: " + e.getMessage());
+            return 2;
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+            return 2;
+        } finally {
+            linter.close();
+        }
+    }
+    
+    private LinterConfiguration loadLinterConfiguration(CLIConfig config) throws IOException {
+        Path configFile = config.getConfigFile();
+        
+        if (configFile == null) {
+            // Look for default config file in current directory
+            Path defaultConfig = Paths.get(DEFAULT_CONFIG_FILE);
+            if (Files.exists(defaultConfig)) {
+                configFile = defaultConfig;
+            } else {
+                // Return empty configuration
+                return LinterConfiguration.builder().build();
+            }
+        }
+        
+        if (!Files.exists(configFile)) {
+            throw new IOException("Configuration file not found: " + configFile);
+        }
+        
+        return configurationLoader.loadConfiguration(configFile);
+    }
+    
+    private int determineExitCode(ValidationResult result, Severity failLevel) {
+        switch (failLevel) {
+            case ERROR:
+                return result.hasErrors() ? 1 : 0;
+            case WARN:
+                return (result.hasErrors() || result.hasWarnings()) ? 1 : 0;
+            case INFO:
+                return result.hasMessages() ? 1 : 0;
+            default:
+                return 0;
+        }
+    }
+    
+    private ValidationResult aggregateResults(Map<Path, ValidationResult> results) {
+        ValidationResult.Builder aggregated = ValidationResult.builder();
+        
+        for (Map.Entry<Path, ValidationResult> entry : results.entrySet()) {
+            for (ValidationMessage message : entry.getValue().getMessages()) {
+                aggregated.addMessage(message);
+            }
+        }
+        
+        return aggregated.complete().build();
+    }
+}

--- a/src/main/java/com/example/linter/cli/FileDiscoveryService.java
+++ b/src/main/java/com/example/linter/cli/FileDiscoveryService.java
@@ -1,0 +1,59 @@
+package com.example.linter.cli;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Service for discovering AsciiDoc files based on patterns and recursive settings.
+ */
+public class FileDiscoveryService {
+    
+    /**
+     * Discovers files based on the CLI configuration.
+     * 
+     * @param config The CLI configuration
+     * @return List of paths to validate
+     * @throws IOException if an I/O error occurs
+     */
+    public List<Path> discoverFiles(CLIConfig config) throws IOException {
+        Path input = config.getInput();
+        
+        if (Files.isRegularFile(input)) {
+            // Single file
+            return List.of(input);
+        } else if (Files.isDirectory(input)) {
+            // Directory - find matching files
+            return findMatchingFiles(input, config.getPattern(), config.isRecursive());
+        } else {
+            throw new IOException("Input path does not exist or is not accessible: " + input);
+        }
+    }
+    
+    private List<Path> findMatchingFiles(Path directory, String pattern, boolean recursive) throws IOException {
+        List<Path> matchingFiles = new ArrayList<>();
+        PathMatcher pathMatcher = directory.getFileSystem().getPathMatcher("glob:" + pattern);
+        int maxDepth = recursive ? Integer.MAX_VALUE : 1;
+        
+        Files.walkFileTree(directory, new java.util.HashSet<>(), maxDepth, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (pathMatcher.matches(file.getFileName())) {
+                    matchingFiles.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+            
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                // Log warning but continue
+                System.err.println("Warning: Could not access file: " + file + " (" + exc.getMessage() + ")");
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        
+        return matchingFiles;
+    }
+}

--- a/src/main/java/com/example/linter/cli/LinterCLI.java
+++ b/src/main/java/com/example/linter/cli/LinterCLI.java
@@ -1,0 +1,135 @@
+package com.example.linter.cli;
+
+import com.example.linter.config.Severity;
+import org.apache.commons.cli.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Main CLI entry point for the AsciiDoc linter.
+ */
+public class LinterCLI {
+    
+    private static final String VERSION = "1.0.0";
+    private static final String PROGRAM_NAME = "power-adoc-linter";
+    
+    public static void main(String[] args) {
+        LinterCLI cli = new LinterCLI();
+        int exitCode = cli.run(args);
+        System.exit(exitCode);
+    }
+    
+    public int run(String[] args) {
+        CLIOptions cliOptions = new CLIOptions();
+        Options options = cliOptions.getOptions();
+        
+        try {
+            CommandLineParser parser = new DefaultParser();
+            CommandLine cmd = parser.parse(options, args);
+            
+            // Handle help
+            if (cmd.hasOption("help")) {
+                printHelp(options);
+                return 0;
+            }
+            
+            // Handle version
+            if (cmd.hasOption("version")) {
+                printVersion();
+                return 0;
+            }
+            
+            // Parse configuration
+            CLIConfig config = parseConfiguration(cmd);
+            
+            // Run linter
+            CLIRunner runner = new CLIRunner();
+            return runner.run(config);
+            
+        } catch (ParseException e) {
+            System.err.println("Error: " + e.getMessage());
+            System.err.println();
+            printHelp(options);
+            return 2;
+        } catch (IllegalArgumentException e) {
+            System.err.println("Error: " + e.getMessage());
+            return 2;
+        }
+    }
+    
+    private CLIConfig parseConfiguration(CommandLine cmd) {
+        CLIConfig.Builder builder = CLIConfig.builder();
+        
+        // Input (required)
+        String inputPath = cmd.getOptionValue("input");
+        builder.input(Paths.get(inputPath));
+        
+        // Config file
+        if (cmd.hasOption("config")) {
+            builder.configFile(Paths.get(cmd.getOptionValue("config")));
+        }
+        
+        // Report format
+        if (cmd.hasOption("report-format")) {
+            String format = cmd.getOptionValue("report-format");
+            if (!format.equals("console") && !format.equals("json")) {
+                throw new IllegalArgumentException("Invalid report format: " + format + 
+                    ". Valid values are: console, json");
+            }
+            builder.reportFormat(format);
+        }
+        
+        // Report output
+        if (cmd.hasOption("report-output")) {
+            builder.reportOutput(Paths.get(cmd.getOptionValue("report-output")));
+        }
+        
+        // Recursive
+        if (cmd.hasOption("no-recursive")) {
+            builder.recursive(false);
+        } else if (cmd.hasOption("recursive")) {
+            builder.recursive(true);
+        }
+        
+        // Pattern
+        if (cmd.hasOption("pattern")) {
+            builder.pattern(cmd.getOptionValue("pattern"));
+        }
+        
+        // Fail level
+        if (cmd.hasOption("fail-level")) {
+            String level = cmd.getOptionValue("fail-level").toUpperCase();
+            try {
+                builder.failLevel(Severity.valueOf(level));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid fail level: " + level + 
+                    ". Valid values are: error, warn, info");
+            }
+        }
+        
+        return builder.build();
+    }
+    
+    private void printHelp(Options options) {
+        HelpFormatter formatter = new HelpFormatter();
+        formatter.setWidth(100);
+        
+        String header = "\nValidates AsciiDoc files against configurable rules.\n\n";
+        String footer = "\nExamples:\n" +
+            "  " + PROGRAM_NAME + " -i README.adoc\n" +
+            "  " + PROGRAM_NAME + " -i docs/ -f json -o report.json\n" +
+            "  " + PROGRAM_NAME + " --input docs/ --config strict.yaml --fail-level warn\n" +
+            "\nExit codes:\n" +
+            "  0 - Success, no violations or only below fail level\n" +
+            "  1 - Violations at or above fail level found\n" +
+            "  2 - Invalid arguments or runtime error\n";
+        
+        formatter.printHelp(PROGRAM_NAME + " -i <file/directory> [options]", 
+            header, options, footer, false);
+    }
+    
+    private void printVersion() {
+        System.out.println(PROGRAM_NAME + " version " + VERSION);
+    }
+}

--- a/src/main/java/com/example/linter/config/LinterConfiguration.java
+++ b/src/main/java/com/example/linter/config/LinterConfiguration.java
@@ -24,7 +24,7 @@ public final class LinterConfiguration {
         }
 
         public LinterConfiguration build() {
-            Objects.requireNonNull(document, "document is required");
+            // Allow empty configuration
             return new LinterConfiguration(this);
         }
     }

--- a/src/main/java/com/example/linter/report/ReportWriter.java
+++ b/src/main/java/com/example/linter/report/ReportWriter.java
@@ -74,6 +74,35 @@ public class ReportWriter {
         write(result, format, outputPath != null ? outputPath.toString() : null);
     }
     
+    /**
+     * Writes the validation result to a PrintWriter using the specified format.
+     * 
+     * @param result the validation result to write
+     * @param format the output format
+     * @param writer the writer to write to
+     */
+    public void write(ValidationResult result, String format, PrintWriter writer) {
+        Objects.requireNonNull(result, "result must not be null");
+        Objects.requireNonNull(writer, "writer must not be null");
+        
+        ReportFormatter formatter = getFormatter(format);
+        formatter.format(result, writer);
+        writer.flush();
+    }
+    
+    /**
+     * Writes the validation result to the console using the specified format.
+     * 
+     * @param result the validation result to write
+     * @param format the output format
+     */
+    public void writeToConsole(ValidationResult result, String format) {
+        Objects.requireNonNull(result, "result must not be null");
+        
+        ReportFormatter formatter = getFormatter(format);
+        writeToConsole(result, formatter);
+    }
+    
     private void writeToConsole(ValidationResult result, ReportFormatter formatter) {
         try (PrintWriter writer = new PrintWriter(System.out)) {
             formatter.format(result, writer);

--- a/src/main/java/com/example/linter/validator/ValidationResult.java
+++ b/src/main/java/com/example/linter/validator/ValidationResult.java
@@ -55,6 +55,10 @@ public final class ValidationResult {
     public boolean hasWarnings() {
         return messages.stream().anyMatch(msg -> msg.getSeverity() == Severity.WARN);
     }
+    
+    public boolean hasMessages() {
+        return !messages.isEmpty();
+    }
 
     public int getErrorCount() {
         return (int) messages.stream()

--- a/src/test/java/com/example/linter/LinterTest.java
+++ b/src/test/java/com/example/linter/LinterTest.java
@@ -1,0 +1,439 @@
+package com.example.linter;
+
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.loader.ConfigurationLoader;
+import com.example.linter.validator.ValidationMessage;
+import com.example.linter.validator.ValidationResult;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Linter")
+class LinterTest {
+    
+    private Linter linter;
+    
+    @BeforeEach
+    void setUp() {
+        linter = new Linter();
+    }
+    
+    @AfterEach
+    void tearDown() {
+        linter.close();
+    }
+    
+    @Nested
+    @DisplayName("validateFile")
+    class ValidateFileTest {
+        
+        @Test
+        @DisplayName("should throw NullPointerException when file is null")
+        void shouldThrowNullPointerExceptionWhenFileIsNull() {
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            assertThrows(NullPointerException.class, () -> 
+                linter.validateFile(null, config),
+                "file must not be null"
+            );
+        }
+        
+        @Test
+        @DisplayName("should throw NullPointerException when config is null")
+        void shouldThrowNullPointerExceptionWhenConfigIsNull(@TempDir Path tempDir) throws IOException {
+            Path file = tempDir.resolve("test.adoc");
+            Files.writeString(file, "= Test");
+            
+            assertThrows(NullPointerException.class, () -> 
+                linter.validateFile(file, null),
+                "config must not be null"
+            );
+        }
+        
+        @Test
+        @DisplayName("should throw IOException when file does not exist")
+        void shouldThrowIOExceptionWhenFileDoesNotExist(@TempDir Path tempDir) {
+            Path nonExistentFile = tempDir.resolve("non-existent.adoc");
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            IOException exception = assertThrows(IOException.class, () -> 
+                linter.validateFile(nonExistentFile, config)
+            );
+            
+            assertTrue(exception.getMessage().contains("File does not exist"));
+        }
+        
+        @Test
+        @DisplayName("should throw IOException when path is directory")
+        void shouldThrowIOExceptionWhenPathIsDirectory(@TempDir Path tempDir) {
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            IOException exception = assertThrows(IOException.class, () -> 
+                linter.validateFile(tempDir, config)
+            );
+            
+            assertTrue(exception.getMessage().contains("Not a regular file"));
+        }
+        
+        @Test
+        @DisplayName("should validate valid AsciiDoc file")
+        void shouldValidateValidAsciiDocFile(@TempDir Path tempDir) throws IOException {
+            Path file = tempDir.resolve("valid.adoc");
+            Files.writeString(file, """
+                = Valid Document
+                John Doe <john@example.com>
+                v1.0, 2024-01-15
+                
+                == Introduction
+                
+                This is a valid document.
+                """);
+            
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            ValidationResult result = linter.validateFile(file, config);
+            
+            assertNotNull(result);
+            assertFalse(result.hasErrors());
+            assertFalse(result.hasWarnings());
+        }
+        
+        @Test
+        @DisplayName("should validate file with configuration")
+        void shouldValidateFileWithConfiguration(@TempDir Path tempDir) throws IOException {
+            Path file = tempDir.resolve("document.adoc");
+            Files.writeString(file, """
+                = Document Title
+                Author Name
+                
+                == Section
+                
+                Content here.
+                """);
+            
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            ValidationResult result = linter.validateFile(file, config);
+            
+            assertNotNull(result);
+            // With empty config, no validation errors should occur
+            assertEquals(0, result.getErrorCount());
+        }
+    }
+    
+    @Nested
+    @DisplayName("validateFiles")
+    class ValidateFilesTest {
+        
+        @Test
+        @DisplayName("should throw NullPointerException when files is null")
+        void shouldThrowNullPointerExceptionWhenFilesIsNull() {
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            assertThrows(NullPointerException.class, () -> 
+                linter.validateFiles(null, config),
+                "files must not be null"
+            );
+        }
+        
+        @Test
+        @DisplayName("should throw NullPointerException when config is null")
+        void shouldThrowNullPointerExceptionWhenConfigIsNull() {
+            List<Path> files = List.of();
+            
+            assertThrows(NullPointerException.class, () -> 
+                linter.validateFiles(files, null),
+                "config must not be null"
+            );
+        }
+        
+        @Test
+        @DisplayName("should return empty map for empty file list")
+        void shouldReturnEmptyMapForEmptyFileList() {
+            List<Path> files = List.of();
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            Map<Path, ValidationResult> results = linter.validateFiles(files, config);
+            
+            assertNotNull(results);
+            assertTrue(results.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should validate multiple files")
+        void shouldValidateMultipleFiles(@TempDir Path tempDir) throws IOException {
+            Path file1 = tempDir.resolve("file1.adoc");
+            Files.writeString(file1, "= Document 1\n\nContent 1");
+            
+            Path file2 = tempDir.resolve("file2.adoc");
+            Files.writeString(file2, "= Document 2\n\nContent 2");
+            
+            List<Path> files = List.of(file1, file2);
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            Map<Path, ValidationResult> results = linter.validateFiles(files, config);
+            
+            assertNotNull(results);
+            assertEquals(2, results.size());
+            assertTrue(results.containsKey(file1));
+            assertTrue(results.containsKey(file2));
+        }
+        
+        @Test
+        @DisplayName("should create error result for non-existent file")
+        void shouldCreateErrorResultForNonExistentFile(@TempDir Path tempDir) throws IOException {
+            Path existingFile = tempDir.resolve("existing.adoc");
+            Files.writeString(existingFile, "= Existing\n\nContent");
+            
+            Path nonExistentFile = tempDir.resolve("non-existent.adoc");
+            
+            List<Path> files = List.of(existingFile, nonExistentFile);
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            Map<Path, ValidationResult> results = linter.validateFiles(files, config);
+            
+            assertNotNull(results);
+            assertEquals(2, results.size());
+            
+            ValidationResult errorResult = results.get(nonExistentFile);
+            assertNotNull(errorResult);
+            assertTrue(errorResult.hasErrors());
+            assertEquals(1, errorResult.getErrorCount());
+            
+            List<ValidationMessage> messages = errorResult.getMessages();
+            assertEquals(1, messages.size());
+            assertEquals("io-error", messages.get(0).getRuleId());
+        }
+    }
+    
+    @Nested
+    @DisplayName("validateDirectory")
+    class ValidateDirectoryTest {
+        
+        @Test
+        @DisplayName("should throw NullPointerException when directory is null")
+        void shouldThrowNullPointerExceptionWhenDirectoryIsNull() {
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            assertThrows(NullPointerException.class, () -> 
+                linter.validateDirectory(null, "*.adoc", false, config),
+                "directory must not be null"
+            );
+        }
+        
+        @Test
+        @DisplayName("should throw NullPointerException when pattern is null")
+        void shouldThrowNullPointerExceptionWhenPatternIsNull(@TempDir Path tempDir) {
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            assertThrows(NullPointerException.class, () -> 
+                linter.validateDirectory(tempDir, null, false, config),
+                "pattern must not be null"
+            );
+        }
+        
+        @Test
+        @DisplayName("should throw NullPointerException when config is null")
+        void shouldThrowNullPointerExceptionWhenConfigIsNull(@TempDir Path tempDir) {
+            assertThrows(NullPointerException.class, () -> 
+                linter.validateDirectory(tempDir, "*.adoc", false, null),
+                "config must not be null"
+            );
+        }
+        
+        @Test
+        @DisplayName("should throw IOException when path is not directory")
+        void shouldThrowIOExceptionWhenPathIsNotDirectory(@TempDir Path tempDir) throws IOException {
+            Path file = tempDir.resolve("file.txt");
+            Files.writeString(file, "content");
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            IOException exception = assertThrows(IOException.class, () -> 
+                linter.validateDirectory(file, "*.adoc", false, config)
+            );
+            
+            assertTrue(exception.getMessage().contains("Not a directory"));
+        }
+        
+        @Test
+        @DisplayName("should find and validate matching files non-recursively")
+        void shouldFindAndValidateMatchingFilesNonRecursively(@TempDir Path tempDir) throws IOException {
+            Path file1 = tempDir.resolve("test1.adoc");
+            Files.writeString(file1, "= Test 1");
+            
+            Path file2 = tempDir.resolve("test2.adoc");
+            Files.writeString(file2, "= Test 2");
+            
+            Path file3 = tempDir.resolve("other.txt");
+            Files.writeString(file3, "Other content");
+            
+            Path subDir = tempDir.resolve("subdir");
+            Files.createDirectory(subDir);
+            Path file4 = subDir.resolve("test3.adoc");
+            Files.writeString(file4, "= Test 3");
+            
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            Map<Path, ValidationResult> results = linter.validateDirectory(tempDir, "*.adoc", false, config);
+            
+            assertNotNull(results);
+            assertEquals(2, results.size());
+            assertTrue(results.containsKey(file1));
+            assertTrue(results.containsKey(file2));
+            assertFalse(results.containsKey(file3));
+            assertFalse(results.containsKey(file4));
+        }
+        
+        @Test
+        @DisplayName("should find and validate matching files recursively")
+        void shouldFindAndValidateMatchingFilesRecursively(@TempDir Path tempDir) throws IOException {
+            Path file1 = tempDir.resolve("test1.adoc");
+            Files.writeString(file1, "= Test 1");
+            
+            Path subDir = tempDir.resolve("subdir");
+            Files.createDirectory(subDir);
+            Path file2 = subDir.resolve("test2.adoc");
+            Files.writeString(file2, "= Test 2");
+            
+            Path deepDir = subDir.resolve("deep");
+            Files.createDirectory(deepDir);
+            Path file3 = deepDir.resolve("test3.adoc");
+            Files.writeString(file3, "= Test 3");
+            
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            Map<Path, ValidationResult> results = linter.validateDirectory(tempDir, "*.adoc", true, config);
+            
+            assertNotNull(results);
+            assertEquals(3, results.size());
+            assertTrue(results.containsKey(file1));
+            assertTrue(results.containsKey(file2));
+            assertTrue(results.containsKey(file3));
+        }
+        
+        @Test
+        @DisplayName("should return empty map when no files match pattern")
+        void shouldReturnEmptyMapWhenNoFilesMatchPattern(@TempDir Path tempDir) throws IOException {
+            Path file1 = tempDir.resolve("test.txt");
+            Files.writeString(file1, "Text file");
+            
+            Path file2 = tempDir.resolve("other.md");
+            Files.writeString(file2, "Markdown file");
+            
+            LinterConfiguration config = LinterConfiguration.builder().build();
+            
+            Map<Path, ValidationResult> results = linter.validateDirectory(tempDir, "*.adoc", false, config);
+            
+            assertNotNull(results);
+            assertTrue(results.isEmpty());
+        }
+    }
+    
+    @Nested
+    @DisplayName("close")
+    class CloseTest {
+        
+        @Test
+        @DisplayName("should close without error")
+        void shouldCloseWithoutError() {
+            assertDoesNotThrow(() -> linter.close());
+        }
+        
+        @Test
+        @DisplayName("should handle multiple close calls")
+        void shouldHandleMultipleCloseCalls() {
+            assertDoesNotThrow(() -> {
+                linter.close();
+                linter.close();
+            });
+        }
+    }
+    
+    @Nested
+    @DisplayName("Integration")
+    class IntegrationTest {
+        
+        @Test
+        @DisplayName("should validate document with metadata and sections")
+        void shouldValidateDocumentWithMetadataAndSections(@TempDir Path tempDir) throws IOException {
+            Path adocFile = tempDir.resolve("document.adoc");
+            Files.writeString(adocFile, """
+                = Test Document
+                John Doe <john@example.com>
+                v1.0, 2024-01-15
+                
+                == Introduction
+                
+                This is the introduction section.
+                
+                == Main Content
+                
+                This is the main content.
+                
+                [source,java]
+                ----
+                public class Example {
+                    // Code here
+                }
+                ----
+                """);
+            
+            String configYaml = """
+                document:
+                  metadata:
+                    attributes:
+                      - name: title
+                        required: true
+                        severity: error
+                      - name: author
+                        required: true
+                        pattern: "^[A-Z][a-zA-Z\\\\s]+$"
+                        severity: error
+                  sections:
+                    - name: introduction
+                      level: 1
+                      min: 1
+                      max: 1
+                      title:
+                        pattern: "^Introduction$"
+                      allowedBlocks:
+                        - paragraph:
+                            severity: warn
+                    - name: mainContent
+                      level: 1
+                      min: 1
+                      title:
+                        pattern: "^Main.*"
+                      allowedBlocks:
+                        - paragraph:
+                            severity: info
+                        - listing:
+                            severity: warn
+                            language:
+                              required: true
+                              severity: error
+                """;
+            
+            Path configFile = tempDir.resolve("config.yaml");
+            Files.writeString(configFile, configYaml);
+            
+            ConfigurationLoader loader = new ConfigurationLoader();
+            LinterConfiguration config = loader.loadConfiguration(configFile);
+            
+            ValidationResult result = linter.validateFile(adocFile, config);
+            
+            assertNotNull(result);
+            // Just verify the validation completes without throwing exceptions
+            // The actual validation logic is tested in individual validator tests
+            assertTrue(result.getValidationTimeMillis() > 0);
+        }
+    }
+}

--- a/src/test/java/com/example/linter/cli/CLIConfigTest.java
+++ b/src/test/java/com/example/linter/cli/CLIConfigTest.java
@@ -1,0 +1,104 @@
+package com.example.linter.cli;
+
+import com.example.linter.config.Severity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("CLIConfig")
+class CLIConfigTest {
+    
+    @Test
+    @DisplayName("should build with default values")
+    void shouldBuildWithDefaultValues() {
+        // Given/When
+        CLIConfig config = CLIConfig.builder()
+            .input(Paths.get("test.adoc"))
+            .build();
+        
+        // Then
+        assertEquals(Paths.get("test.adoc"), config.getInput());
+        assertNull(config.getConfigFile());
+        assertEquals("console", config.getReportFormat());
+        assertNull(config.getReportOutput());
+        assertTrue(config.isRecursive());
+        assertEquals("*.adoc", config.getPattern());
+        assertEquals(Severity.ERROR, config.getFailLevel());
+        assertFalse(config.isOutputToFile());
+    }
+    
+    @Test
+    @DisplayName("should build with all values set")
+    void shouldBuildWithAllValuesSet() {
+        // Given
+        Path input = Paths.get("/docs");
+        Path configFile = Paths.get("config.yaml");
+        Path output = Paths.get("report.json");
+        
+        // When
+        CLIConfig config = CLIConfig.builder()
+            .input(input)
+            .configFile(configFile)
+            .reportFormat("json")
+            .reportOutput(output)
+            .recursive(false)
+            .pattern("**/*.asciidoc")
+            .failLevel(Severity.WARN)
+            .build();
+        
+        // Then
+        assertEquals(input, config.getInput());
+        assertEquals(configFile, config.getConfigFile());
+        assertEquals("json", config.getReportFormat());
+        assertEquals(output, config.getReportOutput());
+        assertFalse(config.isRecursive());
+        assertEquals("**/*.asciidoc", config.getPattern());
+        assertEquals(Severity.WARN, config.getFailLevel());
+        assertTrue(config.isOutputToFile());
+    }
+    
+    @Test
+    @DisplayName("should require input")
+    void shouldRequireInput() {
+        // When/Then
+        assertThrows(NullPointerException.class, () ->
+            CLIConfig.builder().build());
+    }
+    
+    @Test
+    @DisplayName("should require report format")
+    void shouldRequireReportFormat() {
+        // When/Then
+        assertThrows(NullPointerException.class, () ->
+            CLIConfig.builder()
+                .input(Paths.get("test.adoc"))
+                .reportFormat(null)
+                .build());
+    }
+    
+    @Test
+    @DisplayName("should require pattern")
+    void shouldRequirePattern() {
+        // When/Then
+        assertThrows(NullPointerException.class, () ->
+            CLIConfig.builder()
+                .input(Paths.get("test.adoc"))
+                .pattern(null)
+                .build());
+    }
+    
+    @Test
+    @DisplayName("should require fail level")
+    void shouldRequireFailLevel() {
+        // When/Then
+        assertThrows(NullPointerException.class, () ->
+            CLIConfig.builder()
+                .input(Paths.get("test.adoc"))
+                .failLevel(null)
+                .build());
+    }
+}

--- a/src/test/java/com/example/linter/cli/CLIOptionsTest.java
+++ b/src/test/java/com/example/linter/cli/CLIOptionsTest.java
@@ -1,0 +1,110 @@
+package com.example.linter.cli;
+
+import org.apache.commons.cli.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("CLIOptions")
+class CLIOptionsTest {
+    
+    private CLIOptions cliOptions;
+    private CommandLineParser parser;
+    
+    @BeforeEach
+    void setUp() {
+        cliOptions = new CLIOptions();
+        parser = new DefaultParser();
+    }
+    
+    @Test
+    @DisplayName("should parse short form arguments")
+    void shouldParseShortFormArguments() throws ParseException {
+        // Given
+        String[] args = {"-i", "test.adoc", "-c", "config.yaml", "-f", "json", "-o", "report.json"};
+        
+        // When
+        CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
+        
+        // Then
+        assertTrue(cmd.hasOption("i"));
+        assertEquals("test.adoc", cmd.getOptionValue("i"));
+        assertEquals("config.yaml", cmd.getOptionValue("c"));
+        assertEquals("json", cmd.getOptionValue("f"));
+        assertEquals("report.json", cmd.getOptionValue("o"));
+    }
+    
+    @Test
+    @DisplayName("should parse long form arguments")
+    void shouldParseLongFormArguments() throws ParseException {
+        // Given
+        String[] args = {"--input", "test.adoc", "--config", "config.yaml", 
+                        "--report-format", "json", "--report-output", "report.json"};
+        
+        // When
+        CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
+        
+        // Then
+        assertTrue(cmd.hasOption("input"));
+        assertEquals("test.adoc", cmd.getOptionValue("input"));
+        assertEquals("config.yaml", cmd.getOptionValue("config"));
+        assertEquals("json", cmd.getOptionValue("report-format"));
+        assertEquals("report.json", cmd.getOptionValue("report-output"));
+    }
+    
+    @Test
+    @DisplayName("should require input parameter")
+    void shouldRequireInputParameter() {
+        // Given
+        String[] args = {"-c", "config.yaml"};
+        
+        // When/Then
+        assertThrows(ParseException.class, () -> 
+            parser.parse(cliOptions.getOptions(), args));
+    }
+    
+    @Test
+    @DisplayName("should parse boolean flags")
+    void shouldParseBooleanFlags() throws ParseException {
+        // Given
+        String[] args = {"-i", "test.adoc", "-r", "-h", "-v"};
+        
+        // When
+        CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
+        
+        // Then
+        assertTrue(cmd.hasOption("recursive"));
+        assertTrue(cmd.hasOption("help"));
+        assertTrue(cmd.hasOption("version"));
+    }
+    
+    @Test
+    @DisplayName("should parse no-recursive flag")
+    void shouldParseNoRecursiveFlag() throws ParseException {
+        // Given
+        String[] args = {"-i", "test.adoc", "--no-recursive"};
+        
+        // When
+        CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
+        
+        // Then
+        assertTrue(cmd.hasOption("no-recursive"));
+        assertFalse(cmd.hasOption("recursive"));
+    }
+    
+    @Test
+    @DisplayName("should parse pattern and fail-level")
+    void shouldParsePatternAndFailLevel() throws ParseException {
+        // Given
+        String[] args = {"-i", "test.adoc", "-p", "**/*.asciidoc", "-l", "warn"};
+        
+        // When
+        CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
+        
+        // Then
+        assertEquals("**/*.asciidoc", cmd.getOptionValue("pattern"));
+        assertEquals("warn", cmd.getOptionValue("fail-level"));
+    }
+}

--- a/src/test/java/com/example/linter/cli/FileDiscoveryServiceTest.java
+++ b/src/test/java/com/example/linter/cli/FileDiscoveryServiceTest.java
@@ -1,0 +1,165 @@
+package com.example.linter.cli;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("FileDiscoveryService")
+class FileDiscoveryServiceTest {
+    
+    @TempDir
+    Path tempDir;
+    
+    private FileDiscoveryService service;
+    
+    @BeforeEach
+    void setUp() {
+        service = new FileDiscoveryService();
+    }
+    
+    @Test
+    @DisplayName("should return single file when input is file")
+    void shouldReturnSingleFileWhenInputIsFile() throws IOException {
+        // Given
+        Path file = tempDir.resolve("test.adoc");
+        Files.createFile(file);
+        
+        CLIConfig config = CLIConfig.builder()
+            .input(file)
+            .build();
+        
+        // When
+        List<Path> files = service.discoverFiles(config);
+        
+        // Then
+        assertEquals(1, files.size());
+        assertEquals(file, files.get(0));
+    }
+    
+    @Test
+    @DisplayName("should find matching files in directory")
+    void shouldFindMatchingFilesInDirectory() throws IOException {
+        // Given
+        Files.createFile(tempDir.resolve("doc1.adoc"));
+        Files.createFile(tempDir.resolve("doc2.adoc"));
+        Files.createFile(tempDir.resolve("readme.txt"));
+        
+        CLIConfig config = CLIConfig.builder()
+            .input(tempDir)
+            .pattern("*.adoc")
+            .build();
+        
+        // When
+        List<Path> files = service.discoverFiles(config);
+        
+        // Then
+        assertEquals(2, files.size());
+        assertTrue(files.stream().anyMatch(p -> p.getFileName().toString().equals("doc1.adoc")));
+        assertTrue(files.stream().anyMatch(p -> p.getFileName().toString().equals("doc2.adoc")));
+    }
+    
+    @Test
+    @DisplayName("should find files recursively")
+    void shouldFindFilesRecursively() throws IOException {
+        // Given
+        Path subDir = tempDir.resolve("subdir");
+        Files.createDirectory(subDir);
+        Files.createFile(tempDir.resolve("root.adoc"));
+        Files.createFile(subDir.resolve("nested.adoc"));
+        
+        CLIConfig config = CLIConfig.builder()
+            .input(tempDir)
+            .pattern("*.adoc")
+            .recursive(true)
+            .build();
+        
+        // When
+        List<Path> files = service.discoverFiles(config);
+        
+        // Then
+        assertEquals(2, files.size());
+    }
+    
+    @Test
+    @DisplayName("should not find files recursively when disabled")
+    void shouldNotFindFilesRecursivelyWhenDisabled() throws IOException {
+        // Given
+        Path subDir = tempDir.resolve("subdir");
+        Files.createDirectory(subDir);
+        Files.createFile(tempDir.resolve("root.adoc"));
+        Files.createFile(subDir.resolve("nested.adoc"));
+        
+        CLIConfig config = CLIConfig.builder()
+            .input(tempDir)
+            .pattern("*.adoc")
+            .recursive(false)
+            .build();
+        
+        // When
+        List<Path> files = service.discoverFiles(config);
+        
+        // Then
+        assertEquals(1, files.size());
+        assertEquals("root.adoc", files.get(0).getFileName().toString());
+    }
+    
+    @Test
+    @DisplayName("should handle custom patterns")
+    void shouldHandleCustomPatterns() throws IOException {
+        // Given
+        Files.createFile(tempDir.resolve("doc.adoc"));
+        Files.createFile(tempDir.resolve("manual.asciidoc"));
+        Files.createFile(tempDir.resolve("readme.asc"));
+        
+        CLIConfig config = CLIConfig.builder()
+            .input(tempDir)
+            .pattern("*.asciidoc")
+            .build();
+        
+        // When
+        List<Path> files = service.discoverFiles(config);
+        
+        // Then
+        assertEquals(1, files.size());
+        assertEquals("manual.asciidoc", files.get(0).getFileName().toString());
+    }
+    
+    @Test
+    @DisplayName("should throw exception for non-existent input")
+    void shouldThrowExceptionForNonExistentInput() {
+        // Given
+        Path nonExistent = tempDir.resolve("non-existent");
+        CLIConfig config = CLIConfig.builder()
+            .input(nonExistent)
+            .build();
+        
+        // When/Then
+        assertThrows(IOException.class, () -> service.discoverFiles(config));
+    }
+    
+    @Test
+    @DisplayName("should return empty list when no files match")
+    void shouldReturnEmptyListWhenNoFilesMatch() throws IOException {
+        // Given
+        Files.createFile(tempDir.resolve("readme.txt"));
+        
+        CLIConfig config = CLIConfig.builder()
+            .input(tempDir)
+            .pattern("*.adoc")
+            .build();
+        
+        // When
+        List<Path> files = service.discoverFiles(config);
+        
+        // Then
+        assertTrue(files.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented CLI interface using Apache Commons CLI 1.9.0
- Created central Linter class for reusable validation logic
- Added executable JAR creation with Maven Shade Plugin

## Changes
- Added `Linter` class providing validateFile(), validateFiles(), and validateDirectory() methods
- Implemented CLI with proper argument parsing (short and long options)
- Required: --input/-i for file/directory to validate
- Optional: --config/-c, --report-format/-f, --report-output/-o, --pattern/-p, --recursive/-r, --fail-level/-l
- Support for both console and JSON output formats
- Proper exit codes: 0=success, 1=violations found, 2=error

## Test plan
- [x] Build executable JAR: `mvn clean package`
- [x] Test help command: `java -jar target/power-adoc-linter.jar --help`
- [x] Test single file validation
- [x] Test directory validation with pattern
- [x] Test JSON output format
- [x] Test output to file
- [x] All unit tests pass