### PR TITLE
#21 Refactor AbstractBlock to implement Block interface

### DIFF
--- a/src/main/java/com/example/linter/config/blocks/AbstractBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/AbstractBlock.java
@@ -6,7 +6,7 @@ import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
 import com.example.linter.config.rule.OccurrenceConfig;
 
-public abstract class AbstractBlock {
+public abstract class AbstractBlock implements Block {
     private final String name;
     private final Severity severity;
     private final OccurrenceConfig occurrence;

--- a/src/main/java/com/example/linter/config/blocks/Block.java
+++ b/src/main/java/com/example/linter/config/blocks/Block.java
@@ -1,0 +1,12 @@
+package com.example.linter.config.blocks;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.OccurrenceConfig;
+
+public interface Block {
+    BlockType getType();
+    String getName();
+    Severity getSeverity();
+    OccurrenceConfig getOccurrence();
+}

--- a/src/main/java/com/example/linter/config/loader/ConfigurationLoader.java
+++ b/src/main/java/com/example/linter/config/loader/ConfigurationLoader.java
@@ -19,7 +19,7 @@ import com.example.linter.config.DocumentConfiguration;
 import com.example.linter.config.LinterConfiguration;
 import com.example.linter.config.MetadataConfiguration;
 import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.ImageBlock;
 import com.example.linter.config.blocks.ListingBlock;
 import com.example.linter.config.blocks.ParagraphBlock;
@@ -174,7 +174,7 @@ public class ConfigurationLoader {
                 .build();
         }
         
-        List<AbstractBlock> allowedBlocks = new ArrayList<>();
+        List<Block> allowedBlocks = new ArrayList<>();
         if (raw.containsKey("allowedBlocks")) {
             List<Map<String, Object>> blocksRaw = (List<Map<String, Object>>) raw.get("allowedBlocks");
             for (Map<String, Object> blockRaw : blocksRaw) {
@@ -205,7 +205,7 @@ public class ConfigurationLoader {
         return builder.build();
     }
     
-    private AbstractBlock parseBlock(Map<String, Object> raw) {
+    private Block parseBlock(Map<String, Object> raw) {
         // The YAML structure has block type as key (e.g., "paragraph:", "listing:")
         Map.Entry<String, Object> entry = raw.entrySet().iterator().next();
         String blockTypeStr = entry.getKey();

--- a/src/main/java/com/example/linter/config/rule/SectionConfig.java
+++ b/src/main/java/com/example/linter/config/rule/SectionConfig.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 
 public final class SectionConfig {
     private final String name;
@@ -14,7 +14,7 @@ public final class SectionConfig {
     private final int min;
     private final int max;
     private final TitleConfig title;
-    private final List<AbstractBlock> allowedBlocks;
+    private final List<Block> allowedBlocks;
     private final List<SectionConfig> subsections;
 
     private SectionConfig(Builder builder) {
@@ -34,7 +34,7 @@ public final class SectionConfig {
     public int min() { return min; }
     public int max() { return max; }
     public TitleConfig title() { return title; }
-    public List<AbstractBlock> allowedBlocks() { return allowedBlocks; }
+    public List<Block> allowedBlocks() { return allowedBlocks; }
     public List<SectionConfig> subsections() { return subsections; }
 
     public static Builder builder() {
@@ -48,7 +48,7 @@ public final class SectionConfig {
         private int min = 0;
         private int max = Integer.MAX_VALUE;
         private TitleConfig title;
-        private List<AbstractBlock> allowedBlocks = new ArrayList<>();
+        private List<Block> allowedBlocks = new ArrayList<>();
         private List<SectionConfig> subsections = new ArrayList<>();
 
         public Builder name(String name) {
@@ -81,12 +81,12 @@ public final class SectionConfig {
             return this;
         }
 
-        public Builder allowedBlocks(List<AbstractBlock> allowedBlocks) {
+        public Builder allowedBlocks(List<Block> allowedBlocks) {
             this.allowedBlocks = allowedBlocks != null ? new ArrayList<>(allowedBlocks) : new ArrayList<>();
             return this;
         }
 
-        public Builder addAllowedBlock(AbstractBlock block) {
+        public Builder addAllowedBlock(Block block) {
             this.allowedBlocks.add(block);
             return this;
         }

--- a/src/main/java/com/example/linter/validator/BlockValidator.java
+++ b/src/main/java/com/example/linter/validator/BlockValidator.java
@@ -9,7 +9,7 @@ import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.rule.SectionConfig;
 import com.example.linter.validator.block.BlockOccurrenceValidator;
 import com.example.linter.validator.block.BlockOrderValidator;
@@ -108,7 +108,7 @@ public final class BlockValidator {
             }
             
             // Find matching configuration
-            AbstractBlock blockConfig = findBlockConfig(actualType, block, config.allowedBlocks());
+            Block blockConfig = findBlockConfig(actualType, block, config.allowedBlocks());
             
             if (blockConfig != null) {
                 // Track the block
@@ -135,14 +135,14 @@ public final class BlockValidator {
     /**
      * Finds the configuration for a specific block.
      */
-    private AbstractBlock findBlockConfig(BlockType type, 
+    private Block findBlockConfig(BlockType type, 
                                         StructuralNode block,
-                                        List<AbstractBlock> configs) {
+                                        List<Block> configs) {
         // First try to match by name attribute
         Object nameAttr = block.getAttribute("name");
         if (nameAttr != null) {
             String name = nameAttr.toString();
-            for (AbstractBlock config : configs) {
+            for (Block config : configs) {
                 if (config.getType() == type && name.equals(config.getName())) {
                     return config;
                 }
@@ -150,7 +150,7 @@ public final class BlockValidator {
         }
         
         // Then match by type only
-        for (AbstractBlock config : configs) {
+        for (Block config : configs) {
             if (config.getType() == type && config.getName() == null) {
                 return config;
             }

--- a/src/main/java/com/example/linter/validator/block/BlockOccurrenceValidator.java
+++ b/src/main/java/com/example/linter/validator/block/BlockOccurrenceValidator.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.validator.ValidationMessage;
 
 /**
@@ -20,13 +20,13 @@ public final class BlockOccurrenceValidator {
      * @return list of validation messages
      */
     public List<ValidationMessage> validate(BlockValidationContext context,
-                                          List<AbstractBlock> blocks) {
+                                          List<Block> blocks) {
         Objects.requireNonNull(context, "context must not be null");
         Objects.requireNonNull(blocks, "blocks must not be null");
         
         List<ValidationMessage> messages = new ArrayList<>();
         
-        for (AbstractBlock block : blocks) {
+        for (Block block : blocks) {
             if (block.getOccurrence() != null) {
                 validateOccurrences(block, context, messages);
             }
@@ -38,7 +38,7 @@ public final class BlockOccurrenceValidator {
     /**
      * Validates occurrences for a specific block configuration.
      */
-    private void validateOccurrences(AbstractBlock block,
+    private void validateOccurrences(Block block,
                                    BlockValidationContext context,
                                    List<ValidationMessage> messages) {
         

--- a/src/main/java/com/example/linter/validator/block/BlockOrderValidator.java
+++ b/src/main/java/com/example/linter/validator/block/BlockOrderValidator.java
@@ -3,7 +3,7 @@ package com.example.linter.validator.block;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.rule.OrderConfig;
 import com.example.linter.validator.ValidationMessage;
 
@@ -184,7 +184,7 @@ public final class BlockOrderValidator {
     /**
      * Gets the identifier for a block (name or type).
      */
-    private String getBlockIdentifier(AbstractBlock block) {
+    private String getBlockIdentifier(Block block) {
         if (block.getName() != null) {
             return block.getName();
         }

--- a/src/main/java/com/example/linter/validator/block/BlockTypeValidator.java
+++ b/src/main/java/com/example/linter/validator/block/BlockTypeValidator.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.validator.ValidationMessage;
 
 /**
@@ -30,6 +30,6 @@ public interface BlockTypeValidator {
      * @return list of validation messages (errors, warnings, info)
      */
     List<ValidationMessage> validate(StructuralNode block, 
-                                   AbstractBlock config,
+                                   Block config,
                                    BlockValidationContext context);
 }

--- a/src/main/java/com/example/linter/validator/block/BlockValidationContext.java
+++ b/src/main/java/com/example/linter/validator/block/BlockValidationContext.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import org.asciidoctor.ast.Section;
 import org.asciidoctor.ast.StructuralNode;
 
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.validator.SourceLocation;
 
 /**
@@ -55,7 +55,7 @@ public final class BlockValidationContext {
     /**
      * Tracks a block occurrence for validation.
      */
-    public void trackBlock(AbstractBlock config, StructuralNode block) {
+    public void trackBlock(Block config, StructuralNode block) {
         String key = createOccurrenceKey(config);
         
         BlockOccurrence occurrence = new BlockOccurrence(config, block, blockOrder.size());
@@ -67,7 +67,7 @@ public final class BlockValidationContext {
     /**
      * Gets all occurrences for a specific block configuration.
      */
-    public List<BlockOccurrence> getOccurrences(AbstractBlock config) {
+    public List<BlockOccurrence> getOccurrences(Block config) {
         String key = createOccurrenceKey(config);
         return occurrences.getOrDefault(key, Collections.emptyList());
     }
@@ -75,7 +75,7 @@ public final class BlockValidationContext {
     /**
      * Gets the count of occurrences for a specific block configuration.
      */
-    public int getOccurrenceCount(AbstractBlock config) {
+    public int getOccurrenceCount(Block config) {
         return getOccurrences(config).size();
     }
     
@@ -89,14 +89,14 @@ public final class BlockValidationContext {
     /**
      * Gets a human-readable name for the block.
      */
-    public String getBlockName(AbstractBlock config) {
+    public String getBlockName(Block config) {
         if (config.getName() != null) {
             return "block '" + config.getName() + "'";
         }
         return config.getType().toString().toLowerCase() + " block";
     }
     
-    private String createOccurrenceKey(AbstractBlock config) {
+    private String createOccurrenceKey(Block config) {
         if (config.getName() != null) {
             return config.getType() + ":" + config.getName();
         }
@@ -107,17 +107,17 @@ public final class BlockValidationContext {
      * Represents a block occurrence with its configuration and position.
      */
     public static final class BlockOccurrence {
-        private final AbstractBlock config;
+        private final Block config;
         private final StructuralNode block;
         private final int position;
         
-        BlockOccurrence(AbstractBlock config, StructuralNode block, int position) {
+        BlockOccurrence(Block config, StructuralNode block, int position) {
             this.config = config;
             this.block = block;
             this.position = position;
         }
         
-        public AbstractBlock getConfig() { return config; }
+        public Block getConfig() { return config; }
         public StructuralNode getBlock() { return block; }
         public int getPosition() { return position; }
     }
@@ -126,17 +126,17 @@ public final class BlockValidationContext {
      * Represents a block's position in the document.
      */
     public static final class BlockPosition {
-        private final AbstractBlock config;
+        private final Block config;
         private final StructuralNode block;
         private final int index;
         
-        BlockPosition(AbstractBlock config, StructuralNode block, int index) {
+        BlockPosition(Block config, StructuralNode block, int index) {
             this.config = config;
             this.block = block;
             this.index = index;
         }
         
-        public AbstractBlock getConfig() { return config; }
+        public Block getConfig() { return config; }
         public StructuralNode getBlock() { return block; }
         public int getIndex() { return index; }
     }

--- a/src/main/java/com/example/linter/validator/block/ImageBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/ImageBlockValidator.java
@@ -7,7 +7,7 @@ import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.ImageBlock;
 import com.example.linter.validator.ValidationMessage;
 
@@ -23,7 +23,7 @@ public final class ImageBlockValidator implements BlockTypeValidator {
     
     @Override
     public List<ValidationMessage> validate(StructuralNode block, 
-                                          AbstractBlock config,
+                                          Block config,
                                           BlockValidationContext context) {
         
         ImageBlock imageConfig = (ImageBlock) config;

--- a/src/main/java/com/example/linter/validator/block/ListingBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/ListingBlockValidator.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.ListingBlock;
 import com.example.linter.validator.ValidationMessage;
 
@@ -22,7 +22,7 @@ public final class ListingBlockValidator implements BlockTypeValidator {
     
     @Override
     public List<ValidationMessage> validate(StructuralNode block, 
-                                          AbstractBlock config,
+                                          Block config,
                                           BlockValidationContext context) {
         
         ListingBlock listingConfig = (ListingBlock) config;

--- a/src/main/java/com/example/linter/validator/block/ParagraphBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/ParagraphBlockValidator.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.ParagraphBlock;
 import com.example.linter.validator.ValidationMessage;
 
@@ -22,7 +22,7 @@ public final class ParagraphBlockValidator implements BlockTypeValidator {
     
     @Override
     public List<ValidationMessage> validate(StructuralNode block, 
-                                          AbstractBlock config,
+                                          Block config,
                                           BlockValidationContext context) {
         
         ParagraphBlock paragraphConfig = (ParagraphBlock) config;

--- a/src/main/java/com/example/linter/validator/block/TableBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/TableBlockValidator.java
@@ -10,7 +10,7 @@ import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.ast.Table;
 
 import com.example.linter.config.BlockType;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.TableBlock;
 import com.example.linter.validator.ValidationMessage;
 
@@ -26,7 +26,7 @@ public final class TableBlockValidator implements BlockTypeValidator {
     
     @Override
     public List<ValidationMessage> validate(StructuralNode block, 
-                                          AbstractBlock config,
+                                          Block config,
                                           BlockValidationContext context) {
         
         if (!(block instanceof Table)) {

--- a/src/main/java/com/example/linter/validator/block/VerseBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/VerseBlockValidator.java
@@ -7,7 +7,7 @@ import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.VerseBlock;
 import com.example.linter.validator.ValidationMessage;
 
@@ -23,7 +23,7 @@ public final class VerseBlockValidator implements BlockTypeValidator {
     
     @Override
     public List<ValidationMessage> validate(StructuralNode block, 
-                                          AbstractBlock config,
+                                          Block config,
                                           BlockValidationContext context) {
         
         VerseBlock verseConfig = (VerseBlock) config;

--- a/src/test/java/com/example/linter/validator/block/BlockOccurrenceValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/BlockOccurrenceValidatorTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.ParagraphBlock;
 import com.example.linter.config.blocks.TableBlock;
 import com.example.linter.config.rule.OccurrenceConfig;
@@ -46,7 +46,7 @@ class BlockOccurrenceValidatorTest {
         @DisplayName("should return empty list when no blocks configured")
         void shouldReturnEmptyListWhenNoBlocksConfigured() {
             // Given
-            List<AbstractBlock> blocks = new ArrayList<>();
+            List<Block> blocks = new ArrayList<>();
             
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
@@ -62,7 +62,7 @@ class BlockOccurrenceValidatorTest {
             ParagraphBlock block = ParagraphBlock.builder()
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // When
             List<ValidationMessage> messages = validator.validate(context, blocks);
@@ -75,7 +75,7 @@ class BlockOccurrenceValidatorTest {
         @DisplayName("should throw when context is null")
         void shouldThrowWhenContextIsNull() {
             // Given
-            List<AbstractBlock> blocks = new ArrayList<>();
+            List<Block> blocks = new ArrayList<>();
             
             // When/Then
             assertThrows(NullPointerException.class, () -> 
@@ -109,7 +109,7 @@ class BlockOccurrenceValidatorTest {
                 .occurrence(occurrenceConfig)
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // Add only one occurrence to context
             StructuralNode node = mock(StructuralNode.class);
@@ -142,7 +142,7 @@ class BlockOccurrenceValidatorTest {
                 .occurrence(occurrenceConfig)
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // Add two occurrences to context
             StructuralNode node1 = mock(StructuralNode.class);
@@ -171,7 +171,7 @@ class BlockOccurrenceValidatorTest {
                 .occurrence(occurrenceConfig)
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // No blocks tracked in context
             
@@ -205,7 +205,7 @@ class BlockOccurrenceValidatorTest {
                 .occurrence(occurrenceConfig)
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // Add three occurrences to context
             StructuralNode node1 = mock(StructuralNode.class);
@@ -241,7 +241,7 @@ class BlockOccurrenceValidatorTest {
                 .occurrence(occurrenceConfig)
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // Add three occurrences to context (exactly at max)
             StructuralNode node1 = mock(StructuralNode.class);
@@ -289,7 +289,7 @@ class BlockOccurrenceValidatorTest {
                 .severity(Severity.ERROR)
                 .build();
             
-            List<AbstractBlock> blocks = Arrays.asList(paragraphBlock, tableBlock);
+            List<Block> blocks = Arrays.asList(paragraphBlock, tableBlock);
             
             // Add no paragraph blocks (violates min)
             // Add one table block (violates min)
@@ -334,7 +334,7 @@ class BlockOccurrenceValidatorTest {
                 .occurrence(occurrenceConfig)
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // Add two occurrences (violates max)
             StructuralNode node1 = mock(StructuralNode.class);
@@ -371,7 +371,7 @@ class BlockOccurrenceValidatorTest {
                 .occurrence(occurrenceConfig)
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // Test with exactly 3 occurrences
             StructuralNode node1 = mock(StructuralNode.class);
@@ -401,7 +401,7 @@ class BlockOccurrenceValidatorTest {
                 .occurrence(occurrenceConfig)
                 .severity(Severity.ERROR)
                 .build();
-            List<AbstractBlock> blocks = Arrays.asList(block);
+            List<Block> blocks = Arrays.asList(block);
             
             // Add 4 occurrences
             for (int i = 0; i < 4; i++) {

--- a/src/test/java/com/example/linter/validator/block/BlockValidationContextTest.java
+++ b/src/test/java/com/example/linter/validator/block/BlockValidationContextTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.example.linter.config.BlockType;
-import com.example.linter.config.blocks.AbstractBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.ParagraphBlock;
 import com.example.linter.validator.SourceLocation;
 
@@ -117,7 +117,7 @@ class BlockValidationContextTest {
         @DisplayName("should track block occurrence")
         void shouldTrackBlockOccurrence() {
             // Given
-            AbstractBlock mockConfig = mock(ParagraphBlock.class);
+            Block mockConfig = mock(ParagraphBlock.class);
             StructuralNode mockBlock = mock(StructuralNode.class);
             when(mockConfig.getName()).thenReturn("intro");
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
@@ -133,7 +133,7 @@ class BlockValidationContextTest {
         @DisplayName("should track multiple occurrences of same block")
         void shouldTrackMultipleOccurrencesOfSameBlock() {
             // Given
-            AbstractBlock mockConfig = mock(ParagraphBlock.class);
+            Block mockConfig = mock(ParagraphBlock.class);
             StructuralNode mockBlock1 = mock(StructuralNode.class);
             StructuralNode mockBlock2 = mock(StructuralNode.class);
             when(mockConfig.getName()).thenReturn("intro");
@@ -151,8 +151,8 @@ class BlockValidationContextTest {
         @DisplayName("should track block order")
         void shouldTrackBlockOrder() {
             // Given
-            AbstractBlock config1 = mock(ParagraphBlock.class);
-            AbstractBlock config2 = mock(ParagraphBlock.class);
+            Block config1 = mock(ParagraphBlock.class);
+            Block config2 = mock(ParagraphBlock.class);
             StructuralNode block1 = mock(StructuralNode.class);
             StructuralNode block2 = mock(StructuralNode.class);
             when(config1.getName()).thenReturn("first");
@@ -180,7 +180,7 @@ class BlockValidationContextTest {
         @DisplayName("should return empty list when no occurrences tracked")
         void shouldReturnEmptyListWhenNoOccurrencesTracked() {
             // Given
-            AbstractBlock mockConfig = mock(ParagraphBlock.class);
+            Block mockConfig = mock(ParagraphBlock.class);
             when(mockConfig.getName()).thenReturn("intro");
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
             
@@ -196,7 +196,7 @@ class BlockValidationContextTest {
         @DisplayName("should return tracked occurrences")
         void shouldReturnTrackedOccurrences() {
             // Given
-            AbstractBlock mockConfig = mock(ParagraphBlock.class);
+            Block mockConfig = mock(ParagraphBlock.class);
             StructuralNode mockBlock = mock(StructuralNode.class);
             when(mockConfig.getName()).thenReturn("intro");
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
@@ -222,7 +222,7 @@ class BlockValidationContextTest {
         @DisplayName("should return named block identifier")
         void shouldReturnNamedBlockIdentifier() {
             // Given
-            AbstractBlock mockConfig = mock(ParagraphBlock.class);
+            Block mockConfig = mock(ParagraphBlock.class);
             when(mockConfig.getName()).thenReturn("intro");
             
             // When
@@ -236,7 +236,7 @@ class BlockValidationContextTest {
         @DisplayName("should return type-based identifier when name is null")
         void shouldReturnTypeBasedIdentifierWhenNameIsNull() {
             // Given
-            AbstractBlock mockConfig = mock(ParagraphBlock.class);
+            Block mockConfig = mock(ParagraphBlock.class);
             when(mockConfig.getName()).thenReturn(null);
             when(mockConfig.getType()).thenReturn(BlockType.PARAGRAPH);
             


### PR DESCRIPTION
## Summary
- Introduced new `Block` interface to improve architecture
- Refactored `AbstractBlock` to implement the `Block` interface
- Updated all references throughout the codebase to use `Block` interface instead of `AbstractBlock`

## Changes
- Created `Block.java` interface with core methods: `getType()`, `getName()`, `getSeverity()`, `getOccurrence()`
- Modified `AbstractBlock` to implement `Block` interface
- Updated all classes that used `AbstractBlock` to use `Block` interface:
  - Configuration classes (`SectionConfig`)
  - Configuration loader (`ConfigurationLoader`)
  - All validators (BlockValidator, BlockTypeValidator, etc.)
  - Block-specific validators (ImageBlockValidator, ListingBlockValidator, etc.)
- Updated test files to use Block interface

## Test plan
- [x] All existing tests pass
- [x] Project builds successfully with `mvn clean compile`
- [x] No regression in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)