### PR TITLE
#28 Add sentence validation to Paragraph block type

### DIFF
--- a/docs/linter-config-specification.yaml
+++ b/docs/linter-config-specification.yaml
@@ -472,8 +472,22 @@ document:
         
       allowedBlocks:
         - paragraph:
+            name: "conclusion-summary"  # Optional: Benannte Blöcke für bessere Fehlermeldungen
             severity: error          # PFLICHT: Default-Severity für den gesamten Block
             occurrence:
               min: 1                 # Wenn vorhanden, min. 1 Paragraph
               max: 3
               # Kein severity = verwendet Block-Severity (error)
+            lines:
+              min: 3                 # Mindestens 3 Zeilen pro Paragraph
+              max: 20                # Maximal 20 Zeilen pro Paragraph
+              # Kein severity = verwendet Block-Severity (error)
+            sentence:                # Optional: Satz-Validierung
+              occurrence:
+                min: 3               # Mindestens 3 Sätze pro Paragraph
+                max: 10              # Maximal 10 Sätze pro Paragraph
+                severity: warn       # Optional: Überschreibt Block-Severity
+              words:                 # NUR words verfügbar für Sätze
+                min: 8               # Mindestens 8 Wörter pro Satz
+                max: 25              # Maximal 25 Wörter pro Satz
+                severity: info       # Optional: Überschreibt Block-Severity

--- a/src/main/java/com/example/linter/config/blocks/ParagraphBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/ParagraphBlock.java
@@ -3,7 +3,9 @@ package com.example.linter.config.blocks;
 import java.util.Objects;
 
 import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
 import com.example.linter.config.rule.LineConfig;
+import com.example.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -13,9 +15,13 @@ public final class ParagraphBlock extends AbstractBlock {
     @JsonProperty("lines")
     private final LineConfig lines;
     
+    @JsonProperty("sentence")
+    private final SentenceConfig sentence;
+    
     private ParagraphBlock(Builder builder) {
         super(builder);
         this.lines = builder.lines;
+        this.sentence = builder.sentence;
     }
     
     @Override
@@ -24,6 +30,7 @@ public final class ParagraphBlock extends AbstractBlock {
     }
     
     public LineConfig getLines() { return lines; }
+    public SentenceConfig getSentence() { return sentence; }
     
     public static Builder builder() {
         return new Builder();
@@ -32,9 +39,15 @@ public final class ParagraphBlock extends AbstractBlock {
     @JsonPOJOBuilder(withPrefix = "")
     public static class Builder extends AbstractBuilder<Builder> {
         private LineConfig lines;
+        private SentenceConfig sentence;
         
         public Builder lines(LineConfig lines) {
             this.lines = lines;
+            return this;
+        }
+        
+        public Builder sentence(SentenceConfig sentence) {
+            this.sentence = sentence;
             return this;
         }
         
@@ -51,11 +64,145 @@ public final class ParagraphBlock extends AbstractBlock {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         ParagraphBlock that = (ParagraphBlock) o;
-        return Objects.equals(lines, that.lines);
+        return Objects.equals(lines, that.lines) &&
+               Objects.equals(sentence, that.sentence);
     }
     
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), lines);
+        return Objects.hash(super.hashCode(), lines, sentence);
+    }
+    
+    /**
+     * Configuration for sentence-level validation in paragraph blocks.
+     */
+    @JsonDeserialize(builder = SentenceConfig.Builder.class)
+    public static final class SentenceConfig {
+        @JsonProperty("occurrence")
+        private final OccurrenceConfig occurrence;
+        
+        @JsonProperty("words")
+        private final WordsConfig words;
+        
+        private SentenceConfig(Builder builder) {
+            this.occurrence = builder.occurrence;
+            this.words = builder.words;
+        }
+        
+        public OccurrenceConfig getOccurrence() { return occurrence; }
+        public WordsConfig getWords() { return words; }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private OccurrenceConfig occurrence;
+            private WordsConfig words;
+            
+            @JsonProperty("occurrence")
+            public Builder occurrence(OccurrenceConfig occurrence) {
+                this.occurrence = occurrence;
+                return this;
+            }
+            
+            @JsonProperty("words")
+            public Builder words(WordsConfig words) {
+                this.words = words;
+                return this;
+            }
+            
+            public SentenceConfig build() {
+                return new SentenceConfig(this);
+            }
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SentenceConfig that = (SentenceConfig) o;
+            return Objects.equals(occurrence, that.occurrence) &&
+                   Objects.equals(words, that.words);
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(occurrence, words);
+        }
+    }
+    
+    /**
+     * Configuration for word count validation in sentences.
+     */
+    @JsonDeserialize(builder = WordsConfig.Builder.class)
+    public static final class WordsConfig {
+        @JsonProperty("min")
+        private final Integer min;
+        
+        @JsonProperty("max")
+        private final Integer max;
+        
+        @JsonProperty("severity")
+        private final Severity severity;
+        
+        private WordsConfig(Builder builder) {
+            this.min = builder.min;
+            this.max = builder.max;
+            this.severity = builder.severity;
+        }
+        
+        public Integer getMin() { return min; }
+        public Integer getMax() { return max; }
+        public Severity getSeverity() { return severity; }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private Integer min;
+            private Integer max;
+            private Severity severity;
+            
+            @JsonProperty("min")
+            public Builder min(Integer min) {
+                this.min = min;
+                return this;
+            }
+            
+            @JsonProperty("max")
+            public Builder max(Integer max) {
+                this.max = max;
+                return this;
+            }
+            
+            @JsonProperty("severity")
+            public Builder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public WordsConfig build() {
+                return new WordsConfig(this);
+            }
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            WordsConfig that = (WordsConfig) o;
+            return Objects.equals(min, that.min) &&
+                   Objects.equals(max, that.max) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(min, max, severity);
+        }
     }
 }

--- a/src/main/resources/schemas/blocks/paragraph-block-schema.yaml
+++ b/src/main/resources/schemas/blocks/paragraph-block-schema.yaml
@@ -46,6 +46,49 @@ properties:
         type: integer
         description: Maximum number of lines in the paragraph
         minimum: 1
+      severity:
+        type: string
+        enum: [error, warn, info]
+        description: Severity for line count violations (overrides block severity)
+    additionalProperties: false
+  sentence:
+    type: object
+    description: Sentence-level validation rules
+    properties:
+      occurrence:
+        type: object
+        description: Sentence count validation rules
+        properties:
+          min:
+            type: integer
+            description: Minimum number of sentences per paragraph
+            minimum: 1
+          max:
+            type: integer
+            description: Maximum number of sentences per paragraph
+            minimum: 1
+          severity:
+            type: string
+            enum: [error, warn, info]
+            description: Severity for sentence count violations (overrides block severity)
+        additionalProperties: false
+      words:
+        type: object
+        description: Word count validation rules for sentences
+        properties:
+          min:
+            type: integer
+            description: Minimum number of words per sentence
+            minimum: 1
+          max:
+            type: integer
+            description: Maximum number of words per sentence
+            minimum: 1
+          severity:
+            type: string
+            enum: [error, warn, info]
+            description: Severity for word count violations (overrides block severity)
+        additionalProperties: false
     additionalProperties: false
 required: [severity]
 additionalProperties: false

--- a/src/test/java/com/example/linter/validator/block/ParagraphBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/ParagraphBlockValidatorTest.java
@@ -19,6 +19,7 @@ import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.ParagraphBlock;
 import com.example.linter.config.rule.LineConfig;
+import com.example.linter.config.rule.OccurrenceConfig;
 import com.example.linter.validator.ValidationMessage;
 
 /**
@@ -282,6 +283,407 @@ class ParagraphBlockValidatorTest {
             
             // Then
             assertTrue(messages.isEmpty()); // Has content from child
+        }
+    }
+    
+    @Nested
+    @DisplayName("sentence validation")
+    class SentenceValidation {
+        
+        @Nested
+        @DisplayName("sentence occurrence")
+        class SentenceOccurrence {
+            
+            @Test
+            @DisplayName("should validate minimum sentence count")
+            void shouldValidateMinimumSentenceCount() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .occurrence(OccurrenceConfig.builder()
+                        .min(3)
+                        .severity(Severity.ERROR)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.WARN)
+                    .build();
+                
+                // Content with only 2 sentences
+                when(mockBlock.getContent()).thenReturn("This is the first sentence. This is the second sentence.");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(1, messages.size());
+                ValidationMessage msg = messages.get(0);
+                assertEquals(Severity.ERROR, msg.getSeverity());
+                assertEquals("paragraph.sentence.occurrence.min", msg.getRuleId());
+                assertEquals("Paragraph has too few sentences", msg.getMessage());
+                assertEquals("2", msg.getActualValue().orElse(null));
+                assertEquals("At least 3 sentences", msg.getExpectedValue().orElse(null));
+            }
+            
+            @Test
+            @DisplayName("should validate maximum sentence count")
+            void shouldValidateMaximumSentenceCount() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .occurrence(OccurrenceConfig.builder()
+                        .max(2)
+                        .severity(Severity.WARN)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.ERROR)
+                    .build();
+                
+                // Content with 3 sentences
+                when(mockBlock.getContent()).thenReturn("First sentence. Second sentence. Third sentence.");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(1, messages.size());
+                ValidationMessage msg = messages.get(0);
+                assertEquals(Severity.WARN, msg.getSeverity());
+                assertEquals("paragraph.sentence.occurrence.max", msg.getRuleId());
+                assertEquals("Paragraph has too many sentences", msg.getMessage());
+                assertEquals("3", msg.getActualValue().orElse(null));
+                assertEquals("At most 2 sentences", msg.getExpectedValue().orElse(null));
+            }
+            
+            @Test
+            @DisplayName("should use block severity when occurrence severity is not defined")
+            void shouldUseBlockSeverityWhenOccurrenceSeverityNotDefined() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .occurrence(OccurrenceConfig.builder()
+                        .min(2)
+                        // No severity set
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.INFO)
+                    .build();
+                
+                when(mockBlock.getContent()).thenReturn("Only one sentence here.");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(1, messages.size());
+                ValidationMessage msg = messages.get(0);
+                assertEquals(Severity.INFO, msg.getSeverity(), 
+                    "Should use block severity (INFO) when occurrence severity is not defined");
+            }
+            
+            @Test
+            @DisplayName("should handle empty content with minimum sentences required")
+            void shouldHandleEmptyContentWithMinimumSentencesRequired() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .occurrence(OccurrenceConfig.builder()
+                        .min(1)
+                        .severity(Severity.ERROR)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.ERROR)
+                    .build();
+                
+                when(mockBlock.getContent()).thenReturn("");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(1, messages.size());
+                assertEquals("0", messages.get(0).getActualValue().orElse(null));
+            }
+        }
+        
+        @Nested
+        @DisplayName("words per sentence")
+        class WordsPerSentence {
+            
+            @Test
+            @DisplayName("should validate minimum words per sentence")
+            void shouldValidateMinimumWordsPerSentence() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .words(ParagraphBlock.WordsConfig.builder()
+                        .min(5)
+                        .severity(Severity.ERROR)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.WARN)
+                    .build();
+                
+                // First sentence has only 3 words, second has 5
+                when(mockBlock.getContent()).thenReturn("Too short sentence. This sentence has five words.");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(1, messages.size());
+                ValidationMessage msg = messages.get(0);
+                assertEquals(Severity.ERROR, msg.getSeverity());
+                assertEquals("paragraph.sentence.words.min", msg.getRuleId());
+                assertEquals("Sentence 1 has too few words", msg.getMessage());
+                assertEquals("3 words", msg.getActualValue().orElse(null));
+                assertEquals("At least 5 words", msg.getExpectedValue().orElse(null));
+            }
+            
+            @Test
+            @DisplayName("should validate maximum words per sentence")
+            void shouldValidateMaximumWordsPerSentence() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .words(ParagraphBlock.WordsConfig.builder()
+                        .max(8)
+                        .severity(Severity.WARN)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.ERROR)
+                    .build();
+                
+                // Sentence with 10 words
+                when(mockBlock.getContent()).thenReturn("This sentence has way too many words for the configured maximum limit.");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(1, messages.size());
+                ValidationMessage msg = messages.get(0);
+                assertEquals(Severity.WARN, msg.getSeverity());
+                assertEquals("paragraph.sentence.words.max", msg.getRuleId());
+                assertEquals("Sentence 1 has too many words", msg.getMessage());
+                assertEquals("12 words", msg.getActualValue().orElse(null));
+                assertEquals("At most 8 words", msg.getExpectedValue().orElse(null));
+            }
+            
+            @Test
+            @DisplayName("should use block severity when words severity is not defined")
+            void shouldUseBlockSeverityWhenWordsSeverityNotDefined() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .words(ParagraphBlock.WordsConfig.builder()
+                        .min(5)
+                        // No severity set
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.INFO)
+                    .build();
+                
+                when(mockBlock.getContent()).thenReturn("Short.");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(1, messages.size());
+                ValidationMessage msg = messages.get(0);
+                assertEquals(Severity.INFO, msg.getSeverity(), 
+                    "Should use block severity (INFO) when words severity is not defined");
+            }
+            
+            @Test
+            @DisplayName("should validate multiple sentences for word count")
+            void shouldValidateMultipleSentencesForWordCount() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .words(ParagraphBlock.WordsConfig.builder()
+                        .min(4)
+                        .max(8)
+                        .severity(Severity.ERROR)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.ERROR)
+                    .build();
+                
+                // Mix of valid and invalid sentences
+                when(mockBlock.getContent()).thenReturn(
+                    "Too short. " + // 2 words - too few
+                    "This sentence is just right. " + // 5 words - OK
+                    "This sentence has way too many words to be considered valid." // 12 words - too many
+                );
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(2, messages.size());
+                assertTrue(messages.stream().anyMatch(m -> 
+                    m.getMessage().equals("Sentence 1 has too few words")));
+                assertTrue(messages.stream().anyMatch(m -> 
+                    m.getMessage().equals("Sentence 3 has too many words")));
+            }
+        }
+        
+        @Nested
+        @DisplayName("sentence detection")
+        class SentenceDetection {
+            
+            @Test
+            @DisplayName("should detect sentences with different punctuation")
+            void shouldDetectSentencesWithDifferentPunctuation() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .occurrence(OccurrenceConfig.builder()
+                        .min(3)
+                        .max(3)
+                        .severity(Severity.ERROR)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.ERROR)
+                    .build();
+                
+                // Content with period, question mark, and exclamation mark
+                when(mockBlock.getContent()).thenReturn("This is a statement. Is this a question? This is exciting!");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertTrue(messages.isEmpty()); // Exactly 3 sentences
+            }
+            
+            @Test
+            @DisplayName("should handle multi-line sentences")
+            void shouldHandleMultiLineSentences() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .occurrence(OccurrenceConfig.builder()
+                        .min(2)
+                        .max(2)
+                        .severity(Severity.ERROR)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.ERROR)
+                    .build();
+                
+                // Content with sentences spanning multiple lines
+                when(mockBlock.getContent()).thenReturn(
+                    "This is a long sentence that\nspans multiple lines\nbut is still one sentence. " +
+                    "This is\nanother sentence."
+                );
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertTrue(messages.isEmpty()); // Exactly 2 sentences
+            }
+            
+            @Test
+            @DisplayName("should treat content without sentence ending as one sentence")
+            void shouldTreatContentWithoutSentenceEndingAsOneSentence() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .occurrence(OccurrenceConfig.builder()
+                        .min(1)
+                        .max(1)
+                        .severity(Severity.ERROR)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.ERROR)
+                    .build();
+                
+                // Content without sentence-ending punctuation
+                when(mockBlock.getContent()).thenReturn("This is content without proper punctuation");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertTrue(messages.isEmpty()); // Treated as 1 sentence
+            }
+        }
+        
+        @Nested
+        @DisplayName("complex sentence validation")
+        class ComplexSentenceValidation {
+            
+            @Test
+            @DisplayName("should validate both occurrence and words constraints")
+            void shouldValidateBothOccurrenceAndWordsConstraints() {
+                // Given
+                ParagraphBlock.SentenceConfig sentenceConfig = ParagraphBlock.SentenceConfig.builder()
+                    .occurrence(OccurrenceConfig.builder()
+                        .min(2)
+                        .max(4)
+                        .severity(Severity.WARN)
+                        .build())
+                    .words(ParagraphBlock.WordsConfig.builder()
+                        .min(5)
+                        .max(10)
+                        .severity(Severity.ERROR)
+                        .build())
+                    .build();
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .sentence(sentenceConfig)
+                    .severity(Severity.INFO)
+                    .build();
+                
+                // One sentence with too few words, one with too many
+                when(mockBlock.getContent()).thenReturn(
+                    "Short. " + // 1 word - too few
+                    "This sentence has way too many words and should trigger a validation error for exceeding the limit." // 17 words - too many
+                );
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertEquals(2, messages.size());
+                // Check word violations (should use ERROR severity)
+                assertTrue(messages.stream().anyMatch(m -> 
+                    m.getRuleId().equals("paragraph.sentence.words.min") &&
+                    m.getSeverity() == Severity.ERROR));
+                assertTrue(messages.stream().anyMatch(m -> 
+                    m.getRuleId().equals("paragraph.sentence.words.max") &&
+                    m.getSeverity() == Severity.ERROR));
+            }
+            
+            @Test
+            @DisplayName("should handle no sentence config gracefully")
+            void shouldHandleNoSentenceConfigGracefully() {
+                // Given
+                ParagraphBlock config = ParagraphBlock.builder()
+                    .severity(Severity.ERROR)
+                    .build();
+                
+                when(mockBlock.getContent()).thenReturn("Some content with sentences. Another sentence here.");
+                
+                // When
+                List<ValidationMessage> messages = validator.validate(mockBlock, config, context);
+                
+                // Then
+                assertTrue(messages.isEmpty()); // No sentence validation performed
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR implements sentence-level validation for paragraph blocks as requested in issue #28.

## Changes

- Extended  class with:
  -  inner class containing occurrence and words validation
  -  inner class for word count validation in sentences
  - Full Jackson annotations for YAML parsing support

- Extended  with:
  - Sentence detection logic (splits by , , )
  - Sentence occurrence validation (min/max number of sentences)
  - Words per sentence validation (min/max words per sentence)
  - Support for severity hierarchy (nested config severity overrides block severity)

- Added comprehensive unit tests covering:
  - Sentence occurrence validation
  - Words per sentence validation
  - Severity hierarchy behavior
  - Edge cases (empty content, multi-line sentences, etc.)

- Updated JSON schema for paragraph blocks to include sentence validation
- Added example configuration in 
- Added test in  to verify YAML parsing

## Test Results

All tests pass successfully:
- : 23 tests (including 13 new tests for sentence validation)
- : 15 tests (including 1 new test for sentence YAML parsing)

## Example Configuration

```yaml
paragraph:
  name: "conclusion-summary"
  severity: error
  sentence:
    occurrence:
      min: 3
      max: 10
      severity: warn
    words:
      min: 8
      max: 25
      severity: info
```

Closes #28