### PR TITLE
#30 Implement json-compact report format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,9 @@ java -jar target/power-adoc-linter.jar -i /path/to/docs -p "*.adoc" -r
 # JSON output to file
 java -jar target/power-adoc-linter.jar -i document.adoc -f json -o report.json
 
+# Compact JSON output (single line)
+java -jar target/power-adoc-linter.jar -i document.adoc -f json-compact
+
 # Set fail level (default: error)
 java -jar target/power-adoc-linter.jar -i document.adoc -l warn
 ```
@@ -113,7 +116,7 @@ This is a **prototype** AsciiDoc linter built with Java 17 and Maven. The linter
    - All validators work based on YAML schema structure
 
 5. **Strategy Pattern**: Report formatters
-   - `ReportFormatter` interface with `ConsoleFormatter` and `JsonFormatter`
+   - `ReportFormatter` interface with `ConsoleFormatter`, `JsonFormatter`, and `JsonCompactFormatter`
    - Factory pattern for formatter selection
 
 6. **Severity Hierarchy**: Nested configuration severity overrides block-level severity
@@ -151,7 +154,7 @@ This is a **prototype** AsciiDoc linter built with Java 17 and Maven. The linter
 4. **SectionConfiguration**: Hierarchical section definitions with allowed blocks
 
 5. **Block Types**: 
-   - `ParagraphBlock`: Basic text blocks with line count validation
+   - `ParagraphBlock`: Basic text blocks with line count and sentence validation
    - `ListingBlock`: Code blocks with language, title, and callout support
    - `TableBlock`: Tables with column/row counts, headers, captions
    - `ImageBlock`: Images with URL pattern, dimensions, alt text validation
@@ -256,6 +259,8 @@ This is a **prototype** AsciiDoc linter built with Java 17 and Maven. The linter
 - ✅ Schema validation for configuration files (#12)
 - ✅ Jackson migration with custom deserializers (#23)
 - ✅ Logging framework with Log4j2
+- ✅ Sentence validation for paragraph blocks (#28)
+- ✅ JSON compact format for pipeline integration (#30)
 - ⏳ Additional report formats
 - ⏳ Watch mode for continuous validation
 

--- a/src/main/java/com/example/linter/cli/CLIOptions.java
+++ b/src/main/java/com/example/linter/cli/CLIOptions.java
@@ -38,7 +38,7 @@ public class CLIOptions {
             .longOpt("report-format")
             .hasArg()
             .argName("format")
-            .desc("Report format: console, json (default: console)")
+            .desc("Report format: console, json, json-compact (default: console)")
             .build());
         
         // Report output

--- a/src/main/java/com/example/linter/cli/LinterCLI.java
+++ b/src/main/java/com/example/linter/cli/LinterCLI.java
@@ -83,9 +83,9 @@ public class LinterCLI {
         // Report format
         if (cmd.hasOption("report-format")) {
             String format = cmd.getOptionValue("report-format");
-            if (!format.equals("console") && !format.equals("json")) {
+            if (!format.equals("console") && !format.equals("json") && !format.equals("json-compact")) {
                 throw new IllegalArgumentException("Invalid report format: " + format + 
-                    ". Valid values are: console, json");
+                    ". Valid values are: console, json, json-compact");
             }
             builder.reportFormat(format);
         }

--- a/src/main/java/com/example/linter/report/JsonCompactFormatter.java
+++ b/src/main/java/com/example/linter/report/JsonCompactFormatter.java
@@ -1,0 +1,97 @@
+package com.example.linter.report;
+
+import java.io.PrintWriter;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import com.example.linter.validator.ValidationMessage;
+import com.example.linter.validator.ValidationResult;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/**
+ * Formats validation results as compact JSON (single line).
+ * Produces a structured JSON output without pretty printing, suitable for 
+ * programmatic consumption and log processing.
+ */
+public class JsonCompactFormatter implements ReportFormatter {
+    
+    private static final DateTimeFormatter ISO_FORMATTER = 
+        DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC);
+    
+    private final Gson gson;
+    
+    public JsonCompactFormatter() {
+        this.gson = new GsonBuilder()
+            .disableHtmlEscaping()
+            .create();
+    }
+    
+    @Override
+    public void format(ValidationResult result, PrintWriter writer) {
+        JsonObject root = new JsonObject();
+        
+        // Timestamp
+        root.addProperty("timestamp", ISO_FORMATTER.format(Instant.now()));
+        
+        // Duration
+        root.addProperty("duration", formatDuration(result.getValidationTimeMillis()));
+        
+        // Summary
+        JsonObject summary = new JsonObject();
+        summary.addProperty("totalMessages", result.getMessages().size());
+        summary.addProperty("errors", result.getErrorCount());
+        summary.addProperty("warnings", result.getWarningCount());
+        summary.addProperty("infos", result.getInfoCount());
+        root.add("summary", summary);
+        
+        // Messages
+        JsonArray messages = new JsonArray();
+        for (ValidationMessage msg : result.getMessages()) {
+            JsonObject msgObj = new JsonObject();
+            msgObj.addProperty("file", msg.getLocation().getFilename());
+            msgObj.addProperty("line", msg.getLocation().getStartLine());
+            
+            if (msg.getLocation().getStartColumn() > 1) {
+                msgObj.addProperty("column", msg.getLocation().getStartColumn());
+            }
+            
+            msgObj.addProperty("severity", msg.getSeverity().toString());
+            msgObj.addProperty("message", msg.getMessage());
+            
+            // Optional fields
+            if (msg.getRuleId() != null) {
+                msgObj.addProperty("ruleId", msg.getRuleId());
+            }
+            
+            msg.getActualValue().ifPresent(value -> 
+                msgObj.addProperty("actualValue", value));
+            
+            msg.getExpectedValue().ifPresent(value -> 
+                msgObj.addProperty("expectedValue", value));
+            
+            messages.add(msgObj);
+        }
+        root.add("messages", messages);
+        
+        // Write JSON to PrintWriter as a single line
+        writer.print(gson.toJson(root));
+        writer.flush();
+    }
+    
+    private String formatDuration(long millis) {
+        if (millis < 1000) {
+            return millis + "ms";
+        } else {
+            return String.format("%.3fs", millis / 1000.0);
+        }
+    }
+    
+    @Override
+    public String getName() {
+        return "json-compact";
+    }
+}

--- a/src/main/java/com/example/linter/report/ReportWriter.java
+++ b/src/main/java/com/example/linter/report/ReportWriter.java
@@ -28,6 +28,7 @@ public class ReportWriter {
     private void registerDefaultFormatters() {
         registerFormatter(new ConsoleFormatter());
         registerFormatter(new JsonFormatter());
+        registerFormatter(new JsonCompactFormatter());
     }
     
     /**

--- a/src/test/java/com/example/linter/report/JsonCompactFormatterTest.java
+++ b/src/test/java/com/example/linter/report/JsonCompactFormatterTest.java
@@ -1,0 +1,297 @@
+package com.example.linter.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.Severity;
+import com.example.linter.validator.SourceLocation;
+import com.example.linter.validator.ValidationMessage;
+import com.example.linter.validator.ValidationResult;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Unit tests for {@link JsonCompactFormatter}.
+ * 
+ * <p>This test class validates the behavior of the JSON compact formatter,
+ * which produces single-line JSON output suitable for log processing and
+ * pipeline integration.</p>
+ * 
+ * @see JsonCompactFormatter
+ * @see JsonFormatter
+ */
+@DisplayName("JsonCompactFormatter")
+class JsonCompactFormatterTest {
+    
+    private JsonCompactFormatter formatter;
+    private StringWriter stringWriter;
+    private PrintWriter printWriter;
+    
+    @BeforeEach
+    void setUp() {
+        formatter = new JsonCompactFormatter();
+        stringWriter = new StringWriter();
+        printWriter = new PrintWriter(stringWriter);
+    }
+    
+    @Test
+    @DisplayName("should have correct name")
+    void shouldHaveCorrectName() {
+        // Given/When
+        String name = formatter.getName();
+        
+        // Then
+        assertEquals("json-compact", name);
+    }
+    
+    @Test
+    @DisplayName("should format empty result as single-line JSON")
+    void shouldFormatEmptyResultAsSingleLineJson() {
+        // Given
+        ValidationResult result = ValidationResult.builder()
+            .startTime(System.currentTimeMillis() - 100)
+            .complete()
+            .build();
+        
+        // When
+        formatter.format(result, printWriter);
+        String output = stringWriter.toString();
+        
+        // Then
+        assertNotNull(output);
+        assertFalse(output.contains("\n"), "Output should not contain newlines");
+        assertFalse(output.contains("  "), "Output should not contain indentation");
+        
+        // Parse and verify structure
+        JsonObject json = JsonParser.parseString(output).getAsJsonObject();
+        assertTrue(json.has("timestamp"));
+        assertTrue(json.has("duration"));
+        assertTrue(json.has("summary"));
+        assertTrue(json.has("messages"));
+        
+        JsonObject summary = json.getAsJsonObject("summary");
+        assertEquals(0, summary.get("totalMessages").getAsInt());
+        assertEquals(0, summary.get("errors").getAsInt());
+        assertEquals(0, summary.get("warnings").getAsInt());
+        assertEquals(0, summary.get("infos").getAsInt());
+        
+        JsonArray messages = json.getAsJsonArray("messages");
+        assertEquals(0, messages.size());
+    }
+    
+    @Test
+    @DisplayName("should format result with messages as single-line JSON")
+    void shouldFormatResultWithMessagesAsSingleLineJson() {
+        // Given
+        ValidationResult result = ValidationResult.builder()
+            .startTime(System.currentTimeMillis() - 250)
+            .addMessages(Arrays.asList(
+                ValidationMessage.builder()
+                    .severity(Severity.ERROR)
+                    .ruleId("metadata.required")
+                    .location(SourceLocation.builder()
+                        .filename("test.adoc")
+                        .startLine(1)
+                        .startColumn(5)
+                        .build())
+                    .message("Missing required attribute: title")
+                    .actualValue("null")
+                    .expectedValue("non-empty string")
+                    .build(),
+                ValidationMessage.builder()
+                    .severity(Severity.WARN)
+                    .ruleId("section.order")
+                    .location(SourceLocation.builder()
+                        .filename("test.adoc")
+                        .startLine(10)
+                        .build())
+                    .message("Section order violation")
+                    .build(),
+                ValidationMessage.builder()
+                    .severity(Severity.INFO)
+                    .ruleId("general.info")
+                    .location(SourceLocation.builder()
+                        .filename("test.adoc")
+                        .startLine(20)
+                        .build())
+                    .message("Consider adding description")
+                    .build()
+            ))
+            .complete()
+            .build();
+        
+        // When
+        formatter.format(result, printWriter);
+        String output = stringWriter.toString();
+        
+        // Then
+        assertNotNull(output);
+        assertFalse(output.contains("\n"), "Output should not contain newlines");
+        assertFalse(output.contains("  "), "Output should not contain indentation");
+        
+        // Parse and verify structure
+        JsonObject json = JsonParser.parseString(output).getAsJsonObject();
+        
+        // Verify summary
+        JsonObject summary = json.getAsJsonObject("summary");
+        assertEquals(3, summary.get("totalMessages").getAsInt());
+        assertEquals(1, summary.get("errors").getAsInt());
+        assertEquals(1, summary.get("warnings").getAsInt());
+        assertEquals(1, summary.get("infos").getAsInt());
+        
+        // Verify messages
+        JsonArray messages = json.getAsJsonArray("messages");
+        assertEquals(3, messages.size());
+        
+        // Verify first message (error)
+        JsonObject error = messages.get(0).getAsJsonObject();
+        assertEquals("test.adoc", error.get("file").getAsString());
+        assertEquals(1, error.get("line").getAsInt());
+        assertEquals(5, error.get("column").getAsInt());
+        assertEquals("ERROR", error.get("severity").getAsString());
+        assertEquals("Missing required attribute: title", error.get("message").getAsString());
+        assertEquals("metadata.required", error.get("ruleId").getAsString());
+        assertEquals("null", error.get("actualValue").getAsString());
+        assertEquals("non-empty string", error.get("expectedValue").getAsString());
+        
+        // Verify second message (warning) - no column
+        JsonObject warning = messages.get(1).getAsJsonObject();
+        assertEquals("test.adoc", warning.get("file").getAsString());
+        assertEquals(10, warning.get("line").getAsInt());
+        assertFalse(warning.has("column"));
+        assertEquals("WARN", warning.get("severity").getAsString());
+        assertEquals("section.order", warning.get("ruleId").getAsString());
+        
+        // Verify third message (info)
+        JsonObject info = messages.get(2).getAsJsonObject();
+        assertEquals(20, info.get("line").getAsInt());
+        assertEquals("INFO", info.get("severity").getAsString());
+        assertEquals("general.info", info.get("ruleId").getAsString());
+    }
+    
+    @Test
+    @DisplayName("should format duration correctly")
+    void shouldFormatDurationCorrectly() {
+        // Given - test with milliseconds
+        ValidationResult result1 = ValidationResult.builder()
+            .startTime(System.currentTimeMillis() - 999)
+            .complete()
+            .build();
+        
+        // When
+        formatter.format(result1, printWriter);
+        String output1 = stringWriter.toString();
+        
+        // Then
+        JsonObject json1 = JsonParser.parseString(output1).getAsJsonObject();
+        assertEquals("999ms", json1.get("duration").getAsString());
+        
+        // Given - test with seconds
+        stringWriter = new StringWriter();
+        printWriter = new PrintWriter(stringWriter);
+        ValidationResult result2 = ValidationResult.builder()
+            .startTime(System.currentTimeMillis() - 1500)
+            .complete()
+            .build();
+        
+        // When
+        formatter.format(result2, printWriter);
+        String output2 = stringWriter.toString();
+        
+        // Then
+        JsonObject json2 = JsonParser.parseString(output2).getAsJsonObject();
+        assertEquals("1.500s", json2.get("duration").getAsString());
+    }
+    
+    @Test
+    @DisplayName("should handle messages without optional fields")
+    void shouldHandleMessagesWithoutOptionalFields() {
+        // Given
+        ValidationResult result = ValidationResult.builder()
+            .startTime(System.currentTimeMillis() - 50)
+            .addMessages(Arrays.asList(
+                ValidationMessage.builder()
+                    .severity(Severity.ERROR)
+                    .ruleId("basic.error")
+                    .location(SourceLocation.builder()
+                        .filename("test.adoc")
+                        .startLine(1)
+                        .build())
+                    .message("Basic error")
+                    .build()
+            ))
+            .complete()
+            .build();
+        
+        // When
+        formatter.format(result, printWriter);
+        String output = stringWriter.toString();
+        
+        // Then
+        JsonObject json = JsonParser.parseString(output).getAsJsonObject();
+        JsonArray messages = json.getAsJsonArray("messages");
+        JsonObject message = messages.get(0).getAsJsonObject();
+        
+        // Required fields
+        assertTrue(message.has("file"));
+        assertTrue(message.has("line"));
+        assertTrue(message.has("severity"));
+        assertTrue(message.has("message"));
+        
+        // Optional fields should not be present
+        assertFalse(message.has("column"));
+        assertTrue(message.has("ruleId")); // ruleId is always required in our implementation
+        assertFalse(message.has("actualValue"));
+        assertFalse(message.has("expectedValue"));
+    }
+    
+    @Test
+    @DisplayName("should escape special characters properly")
+    void shouldEscapeSpecialCharactersProperly() {
+        // Given
+        ValidationResult result = ValidationResult.builder()
+            .startTime(System.currentTimeMillis() - 100)
+            .addMessages(Arrays.asList(
+                ValidationMessage.builder()
+                    .severity(Severity.ERROR)
+                    .ruleId("test.escape")
+                    .location(SourceLocation.builder()
+                        .filename("test/with\"quotes\".adoc")
+                        .startLine(1)
+                        .build())
+                    .message("Message with \"quotes\" and backslash\\")
+                    .build()
+            ))
+            .complete()
+            .build();
+        
+        // When
+        formatter.format(result, printWriter);
+        String output = stringWriter.toString();
+        
+        // Then
+        // Verify it's valid JSON
+        JsonObject json = JsonParser.parseString(output).getAsJsonObject();
+        JsonArray messages = json.getAsJsonArray("messages");
+        JsonObject message = messages.get(0).getAsJsonObject();
+        
+        // Gson should handle escaping properly
+        assertEquals("test/with\"quotes\".adoc", message.get("file").getAsString());
+        assertEquals("Message with \"quotes\" and backslash\\", message.get("message").getAsString());
+        
+        // Raw output should contain escaped characters
+        assertTrue(output.contains("\\\"quotes\\\""));
+        assertTrue(output.contains("backslash\\\\"));
+    }
+}


### PR DESCRIPTION
## Summary
- Added new JsonCompactFormatter class that outputs JSON on a single line
- Updated CLI to accept json-compact as a valid report format
- Registered json-compact formatter in ReportWriter

## Details
The json-compact format produces the same JSON structure as the regular json format, but without pretty printing or newlines. This makes it suitable for:
- Log processing pipelines
- Streaming validation results
- Integration with monitoring systems
- CI/CD pipelines that parse JSON output

## Test plan
- [x] Added comprehensive unit tests for JsonCompactFormatter
- [x] Tested CLI accepts -f json-compact option
- [x] Verified single-line output format
- [x] Ensured proper escaping of special characters

🤖 Generated with [Claude Code](https://claude.ai/code)