### PR TITLE
#32 Replace Gson with Jackson for JSON formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,10 @@ This is a **prototype** AsciiDoc linter built with Java 17 and Maven. The linter
 - **Main Entry Point**: `src/main/java/com/example/linter/cli/LinterCLI.java`
 - **Log Configuration**: `src/main/resources/log4j2.xml` - Logging setup
 
+## Git Workflow Notes
+
+- `gh pr soll auch immer den issue closen`
+
 ## Debug Notes
 
 - Debug tests werden nicht mit git commit hinzugefügt. Diese werden nach dem Beheben des Fehlers wieder gelöscht
@@ -283,3 +287,16 @@ This is a **prototype** AsciiDoc linter built with Java 17 and Maven. The linter
   - Actual values found during validation
   - Expected values or criteria for validation
   - Consistent format across all validators
+
+## Role Definition Memory
+
+- Rolle: Du bist eine Java Architekt und Lead Developer mit excellenter Expertise und wendest Best Practices in den Bereichen an
+
+## GitHub Pull Request Workflow
+
+- Nach dem Erstellen eines GitHub Pull Requests (gh pr):
+  - Prüfe die GitHub Actions des Pull Requests auf Fehler
+  - Falls Fehler auftreten, behebe diese umgehend
+```
+
+</invoke>

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,6 @@
         </dependency>
         
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.13.1</version>
-        </dependency>
-        
-        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.9.0</version>

--- a/src/test/java/com/example/linter/report/JsonCompactFormatterTest.java
+++ b/src/test/java/com/example/linter/report/JsonCompactFormatterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
@@ -17,30 +18,30 @@ import com.example.linter.config.Severity;
 import com.example.linter.validator.SourceLocation;
 import com.example.linter.validator.ValidationMessage;
 import com.example.linter.validator.ValidationResult;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * Unit tests for {@link JsonCompactFormatter}.
+ * Unit tests for JSON compact formatting.
  * 
  * <p>This test class validates the behavior of the JSON compact formatter,
  * which produces single-line JSON output suitable for log processing and
  * pipeline integration.</p>
  * 
- * @see JsonCompactFormatter
  * @see JsonFormatter
  */
 @DisplayName("JsonCompactFormatter")
 class JsonCompactFormatterTest {
     
     private JsonFormatter formatter;
+    private ObjectMapper objectMapper;
     private StringWriter stringWriter;
     private PrintWriter printWriter;
     
     @BeforeEach
     void setUp() {
         formatter = JsonFormatter.compact();
+        objectMapper = new ObjectMapper();
         stringWriter = new StringWriter();
         printWriter = new PrintWriter(stringWriter);
     }
@@ -57,7 +58,7 @@ class JsonCompactFormatterTest {
     
     @Test
     @DisplayName("should format empty result as single-line JSON")
-    void shouldFormatEmptyResultAsSingleLineJson() {
+    void shouldFormatEmptyResultAsSingleLineJson() throws IOException {
         // Given
         ValidationResult result = ValidationResult.builder()
             .startTime(System.currentTimeMillis() - 100)
@@ -74,25 +75,26 @@ class JsonCompactFormatterTest {
         assertFalse(output.contains("  "), "Output should not contain indentation");
         
         // Parse and verify structure
-        JsonObject json = JsonParser.parseString(output).getAsJsonObject();
+        JsonNode json = objectMapper.readTree(output);
         assertTrue(json.has("timestamp"));
         assertTrue(json.has("duration"));
         assertTrue(json.has("summary"));
         assertTrue(json.has("messages"));
         
-        JsonObject summary = json.getAsJsonObject("summary");
-        assertEquals(0, summary.get("totalMessages").getAsInt());
-        assertEquals(0, summary.get("errors").getAsInt());
-        assertEquals(0, summary.get("warnings").getAsInt());
-        assertEquals(0, summary.get("infos").getAsInt());
+        JsonNode summary = json.get("summary");
+        assertEquals(0, summary.get("totalMessages").asInt());
+        assertEquals(0, summary.get("errors").asInt());
+        assertEquals(0, summary.get("warnings").asInt());
+        assertEquals(0, summary.get("infos").asInt());
         
-        JsonArray messages = json.getAsJsonArray("messages");
+        JsonNode messages = json.get("messages");
+        assertTrue(messages.isArray());
         assertEquals(0, messages.size());
     }
     
     @Test
     @DisplayName("should format result with messages as single-line JSON")
-    void shouldFormatResultWithMessagesAsSingleLineJson() {
+    void shouldFormatResultWithMessagesAsSingleLineJson() throws IOException {
         // Given
         ValidationResult result = ValidationResult.builder()
             .startTime(System.currentTimeMillis() - 250)
@@ -141,48 +143,48 @@ class JsonCompactFormatterTest {
         assertFalse(output.contains("  "), "Output should not contain indentation");
         
         // Parse and verify structure
-        JsonObject json = JsonParser.parseString(output).getAsJsonObject();
+        JsonNode json = objectMapper.readTree(output);
         
         // Verify summary
-        JsonObject summary = json.getAsJsonObject("summary");
-        assertEquals(3, summary.get("totalMessages").getAsInt());
-        assertEquals(1, summary.get("errors").getAsInt());
-        assertEquals(1, summary.get("warnings").getAsInt());
-        assertEquals(1, summary.get("infos").getAsInt());
+        JsonNode summary = json.get("summary");
+        assertEquals(3, summary.get("totalMessages").asInt());
+        assertEquals(1, summary.get("errors").asInt());
+        assertEquals(1, summary.get("warnings").asInt());
+        assertEquals(1, summary.get("infos").asInt());
         
         // Verify messages
-        JsonArray messages = json.getAsJsonArray("messages");
+        JsonNode messages = json.get("messages");
         assertEquals(3, messages.size());
         
         // Verify first message (error)
-        JsonObject error = messages.get(0).getAsJsonObject();
-        assertEquals("test.adoc", error.get("file").getAsString());
-        assertEquals(1, error.get("line").getAsInt());
-        assertEquals(5, error.get("column").getAsInt());
-        assertEquals("ERROR", error.get("severity").getAsString());
-        assertEquals("Missing required attribute: title", error.get("message").getAsString());
-        assertEquals("metadata.required", error.get("ruleId").getAsString());
-        assertEquals("null", error.get("actualValue").getAsString());
-        assertEquals("non-empty string", error.get("expectedValue").getAsString());
+        JsonNode error = messages.get(0);
+        assertEquals("test.adoc", error.get("file").asText());
+        assertEquals(1, error.get("line").asInt());
+        assertEquals(5, error.get("column").asInt());
+        assertEquals("ERROR", error.get("severity").asText());
+        assertEquals("Missing required attribute: title", error.get("message").asText());
+        assertEquals("metadata.required", error.get("ruleId").asText());
+        assertEquals("null", error.get("actualValue").asText());
+        assertEquals("non-empty string", error.get("expectedValue").asText());
         
         // Verify second message (warning) - no column
-        JsonObject warning = messages.get(1).getAsJsonObject();
-        assertEquals("test.adoc", warning.get("file").getAsString());
-        assertEquals(10, warning.get("line").getAsInt());
+        JsonNode warning = messages.get(1);
+        assertEquals("test.adoc", warning.get("file").asText());
+        assertEquals(10, warning.get("line").asInt());
         assertFalse(warning.has("column"));
-        assertEquals("WARN", warning.get("severity").getAsString());
-        assertEquals("section.order", warning.get("ruleId").getAsString());
+        assertEquals("WARN", warning.get("severity").asText());
+        assertEquals("section.order", warning.get("ruleId").asText());
         
         // Verify third message (info)
-        JsonObject info = messages.get(2).getAsJsonObject();
-        assertEquals(20, info.get("line").getAsInt());
-        assertEquals("INFO", info.get("severity").getAsString());
-        assertEquals("general.info", info.get("ruleId").getAsString());
+        JsonNode info = messages.get(2);
+        assertEquals(20, info.get("line").asInt());
+        assertEquals("INFO", info.get("severity").asText());
+        assertEquals("general.info", info.get("ruleId").asText());
     }
     
     @Test
     @DisplayName("should format duration correctly")
-    void shouldFormatDurationCorrectly() {
+    void shouldFormatDurationCorrectly() throws IOException {
         // Given - test with milliseconds
         ValidationResult result1 = ValidationResult.builder()
             .startTime(System.currentTimeMillis() - 999)
@@ -194,8 +196,8 @@ class JsonCompactFormatterTest {
         String output1 = stringWriter.toString();
         
         // Then
-        JsonObject json1 = JsonParser.parseString(output1).getAsJsonObject();
-        assertEquals("999ms", json1.get("duration").getAsString());
+        JsonNode json1 = objectMapper.readTree(output1);
+        assertEquals("999ms", json1.get("duration").asText());
         
         // Given - test with seconds
         stringWriter = new StringWriter();
@@ -210,13 +212,13 @@ class JsonCompactFormatterTest {
         String output2 = stringWriter.toString();
         
         // Then
-        JsonObject json2 = JsonParser.parseString(output2).getAsJsonObject();
-        assertEquals("1.500s", json2.get("duration").getAsString());
+        JsonNode json2 = objectMapper.readTree(output2);
+        assertEquals("1.500s", json2.get("duration").asText());
     }
     
     @Test
     @DisplayName("should handle messages without optional fields")
-    void shouldHandleMessagesWithoutOptionalFields() {
+    void shouldHandleMessagesWithoutOptionalFields() throws IOException {
         // Given
         ValidationResult result = ValidationResult.builder()
             .startTime(System.currentTimeMillis() - 50)
@@ -239,9 +241,9 @@ class JsonCompactFormatterTest {
         String output = stringWriter.toString();
         
         // Then
-        JsonObject json = JsonParser.parseString(output).getAsJsonObject();
-        JsonArray messages = json.getAsJsonArray("messages");
-        JsonObject message = messages.get(0).getAsJsonObject();
+        JsonNode json = objectMapper.readTree(output);
+        JsonNode messages = json.get("messages");
+        JsonNode message = messages.get(0);
         
         // Required fields
         assertTrue(message.has("file"));
@@ -258,7 +260,7 @@ class JsonCompactFormatterTest {
     
     @Test
     @DisplayName("should escape special characters properly")
-    void shouldEscapeSpecialCharactersProperly() {
+    void shouldEscapeSpecialCharactersProperly() throws IOException {
         // Given
         ValidationResult result = ValidationResult.builder()
             .startTime(System.currentTimeMillis() - 100)
@@ -282,13 +284,13 @@ class JsonCompactFormatterTest {
         
         // Then
         // Verify it's valid JSON
-        JsonObject json = JsonParser.parseString(output).getAsJsonObject();
-        JsonArray messages = json.getAsJsonArray("messages");
-        JsonObject message = messages.get(0).getAsJsonObject();
+        JsonNode json = objectMapper.readTree(output);
+        JsonNode messages = json.get("messages");
+        JsonNode message = messages.get(0);
         
-        // Gson should handle escaping properly
-        assertEquals("test/with\"quotes\".adoc", message.get("file").getAsString());
-        assertEquals("Message with \"quotes\" and backslash\\", message.get("message").getAsString());
+        // Jackson should handle escaping properly
+        assertEquals("test/with\"quotes\".adoc", message.get("file").asText());
+        assertEquals("Message with \"quotes\" and backslash\\", message.get("message").asText());
         
         // Raw output should contain escaped characters
         assertTrue(output.contains("\\\"quotes\\\""));

--- a/src/test/java/com/example/linter/report/ReportWriterTest.java
+++ b/src/test/java/com/example/linter/report/ReportWriterTest.java
@@ -142,8 +142,8 @@ class ReportWriterTest {
             assertTrue(Files.exists(outputFile));
             String content = Files.readString(outputFile);
             assertTrue(content.contains("{"));
-            assertTrue(content.contains("\"severity\": \"ERROR\""));
-            assertTrue(content.contains("\"message\": \"Test error\""));
+            assertTrue(content.contains("\"severity\" : \"ERROR\""));
+            assertTrue(content.contains("\"message\" : \"Test error\""));
         }
         
         @Test


### PR DESCRIPTION
## Summary
- Replaced Gson with Jackson for JSON formatting to reduce dependencies and maintain consistency
- Updated JsonFormatter to use Jackson's ObjectMapper instead of Gson
- Updated JsonCompactFormatterTest to use Jackson for JSON parsing
- Removed Gson dependency from pom.xml
- Fixed test expectations to match Jackson's JSON formatting (includes spaces after colons)

## Benefits
- Reduces JAR size by eliminating redundant JSON library
- Maintains consistency by using Jackson for both YAML and JSON processing
- Simplifies dependency management

Closes #32