### PR TITLE
Consolidate CLI parameters with Ant file pattern support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ mvn clean package
 
 # Run the linter CLI
 java -jar target/power-adoc-linter.jar --help
-java -jar target/power-adoc-linter.jar -i document.adoc -c config.yaml
+java -jar target/power-adoc-linter.jar -i "**/*.adoc"
+java -jar target/power-adoc-linter.jar -i "docs/**/*.adoc,examples/**/*.asciidoc" -c config.yaml
 
 # Check for dependency updates
 mvn versions:display-dependency-updates
@@ -44,23 +45,29 @@ java -Dlog4j.configurationFile=src/main/resources/log4j2.xml -jar target/power-a
 ## CLI Usage
 
 ```bash
-# Basic usage
-java -jar target/power-adoc-linter.jar -i document.adoc
+# Basic usage - validate all AsciiDoc files recursively
+java -jar target/power-adoc-linter.jar -i "**/*.adoc"
+
+# Multiple patterns (comma-separated)
+java -jar target/power-adoc-linter.jar -i "docs/**/*.adoc,examples/**/*.asciidoc,README.adoc"
 
 # With custom configuration
-java -jar target/power-adoc-linter.jar -i document.adoc -c my-rules.yaml
-
-# Validate directory
-java -jar target/power-adoc-linter.jar -i /path/to/docs -p "*.adoc" -r
+java -jar target/power-adoc-linter.jar -i "src/*/docs/**/*.adoc" -c my-rules.yaml
 
 # JSON output to file
-java -jar target/power-adoc-linter.jar -i document.adoc -f json -o report.json
+java -jar target/power-adoc-linter.jar -i "**/*.adoc" -f json -o report.json
 
 # Compact JSON output (single line)
-java -jar target/power-adoc-linter.jar -i document.adoc -f json-compact
+java -jar target/power-adoc-linter.jar -i "**/*.adoc" -f json-compact
 
 # Set fail level (default: error)
-java -jar target/power-adoc-linter.jar -i document.adoc -l warn
+java -jar target/power-adoc-linter.jar -i "**/*.adoc" -l warn
+
+# Ant pattern examples:
+# - "**/*.adoc" - all .adoc files in any directory
+# - "docs/**/*.adoc" - all .adoc files under docs/
+# - "*/docs/*.adoc" - .adoc files in any direct subdirectory's docs folder
+# - "doc?.adoc" - matches doc1.adoc, doc2.adoc, but not docs.adoc
 ```
 
 ## Project Information

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
         </dependency>
         
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.18.0</version>
+        </dependency>
+        
+        <dependency>
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>1.5.7</version>

--- a/src/main/java/com/example/linter/cli/CLIConfig.java
+++ b/src/main/java/com/example/linter/cli/CLIConfig.java
@@ -1,6 +1,8 @@
 package com.example.linter.cli;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.Objects;
 
 import com.example.linter.config.Severity;
@@ -10,26 +12,31 @@ import com.example.linter.config.Severity;
  */
 public class CLIConfig {
     
-    private final Path input;
+    private final List<String> inputPatterns;
+    private final Path baseDirectory;
     private final Path configFile;
     private final String reportFormat;
     private final Path reportOutput;
-    private final boolean recursive;
-    private final String pattern;
     private final Severity failLevel;
     
     private CLIConfig(Builder builder) {
-        this.input = Objects.requireNonNull(builder.input, "input must not be null");
+        this.inputPatterns = Objects.requireNonNull(builder.inputPatterns, "inputPatterns must not be null");
+        if (this.inputPatterns.isEmpty()) {
+            throw new IllegalArgumentException("inputPatterns must not be empty");
+        }
+        this.baseDirectory = Objects.requireNonNull(builder.baseDirectory, "baseDirectory must not be null");
         this.configFile = builder.configFile;
         this.reportFormat = Objects.requireNonNull(builder.reportFormat, "reportFormat must not be null");
         this.reportOutput = builder.reportOutput;
-        this.recursive = builder.recursive;
-        this.pattern = Objects.requireNonNull(builder.pattern, "pattern must not be null");
         this.failLevel = Objects.requireNonNull(builder.failLevel, "failLevel must not be null");
     }
     
-    public Path getInput() {
-        return input;
+    public List<String> getInputPatterns() {
+        return inputPatterns;
+    }
+    
+    public Path getBaseDirectory() {
+        return baseDirectory;
     }
     
     public Path getConfigFile() {
@@ -42,14 +49,6 @@ public class CLIConfig {
     
     public Path getReportOutput() {
         return reportOutput;
-    }
-    
-    public boolean isRecursive() {
-        return recursive;
-    }
-    
-    public String getPattern() {
-        return pattern;
     }
     
     public Severity getFailLevel() {
@@ -65,16 +64,20 @@ public class CLIConfig {
     }
     
     public static class Builder {
-        private Path input;
+        private List<String> inputPatterns;
+        private Path baseDirectory = Paths.get(System.getProperty("user.dir"));
         private Path configFile;
         private String reportFormat = "console";
         private Path reportOutput;
-        private boolean recursive = true;
-        private String pattern = "*.adoc";
         private Severity failLevel = Severity.ERROR;
         
-        public Builder input(Path input) {
-            this.input = input;
+        public Builder inputPatterns(List<String> inputPatterns) {
+            this.inputPatterns = inputPatterns;
+            return this;
+        }
+        
+        public Builder baseDirectory(Path baseDirectory) {
+            this.baseDirectory = baseDirectory;
             return this;
         }
         
@@ -90,16 +93,6 @@ public class CLIConfig {
         
         public Builder reportOutput(Path reportOutput) {
             this.reportOutput = reportOutput;
-            return this;
-        }
-        
-        public Builder recursive(boolean recursive) {
-            this.recursive = recursive;
-            return this;
-        }
-        
-        public Builder pattern(String pattern) {
-            this.pattern = pattern;
             return this;
         }
         

--- a/src/main/java/com/example/linter/cli/CLIOptions.java
+++ b/src/main/java/com/example/linter/cli/CLIOptions.java
@@ -16,12 +16,12 @@ public class CLIOptions {
     }
     
     private void defineOptions() {
-        // Input file/directory (required)
+        // Input patterns (required)
         options.addOption(Option.builder("i")
             .longOpt("input")
             .hasArg()
-            .argName("file/directory")
-            .desc("AsciiDoc file or directory to validate")
+            .argName("patterns")
+            .desc("Comma-separated Ant file patterns (e.g., '**/*.adoc,docs/**/*.asciidoc')")
             .required()
             .build());
         
@@ -47,26 +47,6 @@ public class CLIOptions {
             .hasArg()
             .argName("file/directory")
             .desc("Report output file or directory (default: stdout)")
-            .build());
-        
-        // Recursive
-        options.addOption(Option.builder("r")
-            .longOpt("recursive")
-            .desc("Recursively scan directories (default: true)")
-            .build());
-        
-        // No recursive
-        options.addOption(Option.builder()
-            .longOpt("no-recursive")
-            .desc("Do not scan directories recursively")
-            .build());
-        
-        // Pattern
-        options.addOption(Option.builder("p")
-            .longOpt("pattern")
-            .hasArg()
-            .argName("glob")
-            .desc("File pattern glob (default: *.adoc)")
             .build());
         
         // Fail level

--- a/src/main/java/com/example/linter/cli/CLIRunner.java
+++ b/src/main/java/com/example/linter/cli/CLIRunner.java
@@ -52,7 +52,7 @@ public class CLIRunner {
             List<Path> filesToValidate = fileDiscoveryService.discoverFiles(config);
             
             if (filesToValidate.isEmpty()) {
-                logger.error("No files found matching pattern: {}", config.getPattern());
+                logger.error("No files found matching patterns: {}", String.join(", ", config.getInputPatterns()));
                 return 2;
             }
             

--- a/src/test/java/com/example/linter/cli/CLIOptionsTest.java
+++ b/src/test/java/com/example/linter/cli/CLIOptionsTest.java
@@ -99,18 +99,4 @@ class CLIOptionsTest {
         // Then
         assertEquals("warn", cmd.getOptionValue("fail-level"));
     }
-    
-    @Test
-    @DisplayName("should not have pattern or recursive options")
-    void shouldNotHavePatternOrRecursiveOptions() {
-        // When
-        var options = cliOptions.getOptions();
-        
-        // Then
-        assertFalse(options.hasOption("p"));
-        assertFalse(options.hasOption("pattern"));
-        assertFalse(options.hasOption("r"));
-        assertFalse(options.hasOption("recursive"));
-        assertFalse(options.hasOption("no-recursive"));
-    }
 }

--- a/src/test/java/com/example/linter/cli/CLIOptionsTest.java
+++ b/src/test/java/com/example/linter/cli/CLIOptionsTest.java
@@ -29,14 +29,14 @@ class CLIOptionsTest {
     @DisplayName("should parse short form arguments")
     void shouldParseShortFormArguments() throws ParseException {
         // Given
-        String[] args = {"-i", "test.adoc", "-c", "config.yaml", "-f", "json", "-o", "report.json"};
+        String[] args = {"-i", "**/*.adoc", "-c", "config.yaml", "-f", "json", "-o", "report.json"};
         
         // When
         CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
         
         // Then
         assertTrue(cmd.hasOption("i"));
-        assertEquals("test.adoc", cmd.getOptionValue("i"));
+        assertEquals("**/*.adoc", cmd.getOptionValue("i"));
         assertEquals("config.yaml", cmd.getOptionValue("c"));
         assertEquals("json", cmd.getOptionValue("f"));
         assertEquals("report.json", cmd.getOptionValue("o"));
@@ -46,7 +46,7 @@ class CLIOptionsTest {
     @DisplayName("should parse long form arguments")
     void shouldParseLongFormArguments() throws ParseException {
         // Given
-        String[] args = {"--input", "test.adoc", "--config", "config.yaml", 
+        String[] args = {"--input", "docs/**/*.adoc,examples/**/*.asciidoc", "--config", "config.yaml", 
                         "--report-format", "json", "--report-output", "report.json"};
         
         // When
@@ -54,7 +54,7 @@ class CLIOptionsTest {
         
         // Then
         assertTrue(cmd.hasOption("input"));
-        assertEquals("test.adoc", cmd.getOptionValue("input"));
+        assertEquals("docs/**/*.adoc,examples/**/*.asciidoc", cmd.getOptionValue("input"));
         assertEquals("config.yaml", cmd.getOptionValue("config"));
         assertEquals("json", cmd.getOptionValue("report-format"));
         assertEquals("report.json", cmd.getOptionValue("report-output"));
@@ -72,45 +72,45 @@ class CLIOptionsTest {
     }
     
     @Test
-    @DisplayName("should parse boolean flags")
-    void shouldParseBooleanFlags() throws ParseException {
+    @DisplayName("should parse help and version flags")
+    void shouldParseHelpAndVersionFlags() throws ParseException {
         // Given
-        String[] args = {"-i", "test.adoc", "-r", "-h", "-v"};
+        String[] argsHelp = {"-i", "test.adoc", "-h"};
+        String[] argsVersion = {"-i", "test.adoc", "-v"};
         
         // When
-        CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
+        CommandLine cmdHelp = parser.parse(cliOptions.getOptions(), argsHelp);
+        CommandLine cmdVersion = parser.parse(cliOptions.getOptions(), argsVersion);
         
         // Then
-        assertTrue(cmd.hasOption("recursive"));
-        assertTrue(cmd.hasOption("help"));
-        assertTrue(cmd.hasOption("version"));
+        assertTrue(cmdHelp.hasOption("help"));
+        assertTrue(cmdVersion.hasOption("version"));
     }
     
     @Test
-    @DisplayName("should parse no-recursive flag")
-    void shouldParseNoRecursiveFlag() throws ParseException {
+    @DisplayName("should parse fail level")
+    void shouldParseFailLevel() throws ParseException {
         // Given
-        String[] args = {"-i", "test.adoc", "--no-recursive"};
+        String[] args = {"-i", "**/*.adoc", "-l", "warn"};
         
         // When
         CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
         
         // Then
-        assertTrue(cmd.hasOption("no-recursive"));
-        assertFalse(cmd.hasOption("recursive"));
-    }
-    
-    @Test
-    @DisplayName("should parse pattern and fail-level")
-    void shouldParsePatternAndFailLevel() throws ParseException {
-        // Given
-        String[] args = {"-i", "test.adoc", "-p", "**/*.asciidoc", "-l", "warn"};
-        
-        // When
-        CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
-        
-        // Then
-        assertEquals("**/*.asciidoc", cmd.getOptionValue("pattern"));
         assertEquals("warn", cmd.getOptionValue("fail-level"));
+    }
+    
+    @Test
+    @DisplayName("should not have pattern or recursive options")
+    void shouldNotHavePatternOrRecursiveOptions() {
+        // When
+        var options = cliOptions.getOptions();
+        
+        // Then
+        assertFalse(options.hasOption("p"));
+        assertFalse(options.hasOption("pattern"));
+        assertFalse(options.hasOption("r"));
+        assertFalse(options.hasOption("recursive"));
+        assertFalse(options.hasOption("no-recursive"));
     }
 }

--- a/src/test/java/com/example/linter/cli/FileDiscoveryServiceTest.java
+++ b/src/test/java/com/example/linter/cli/FileDiscoveryServiceTest.java
@@ -1,16 +1,19 @@
 package com.example.linter.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -27,141 +30,311 @@ class FileDiscoveryServiceTest {
         service = new FileDiscoveryService();
     }
     
-    @Test
-    @DisplayName("should return single file when input is file")
-    void shouldReturnSingleFileWhenInputIsFile() throws IOException {
-        // Given
-        Path file = tempDir.resolve("test.adoc");
-        Files.createFile(file);
+    @Nested
+    @DisplayName("Simple file patterns")
+    class SimpleFilePatterns {
         
-        CLIConfig config = CLIConfig.builder()
-            .input(file)
-            .build();
+        @Test
+        @DisplayName("should find single file by exact name")
+        void shouldFindSingleFileByExactName() throws IOException {
+            // Given
+            Path file = tempDir.resolve("README.adoc");
+            Files.createFile(file);
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("README.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(1, files.size());
+            assertEquals(file.normalize(), files.get(0));
+        }
         
-        // When
-        List<Path> files = service.discoverFiles(config);
-        
-        // Then
-        assertEquals(1, files.size());
-        assertEquals(file, files.get(0));
+        @Test
+        @DisplayName("should find files with wildcard pattern")
+        void shouldFindFilesWithWildcardPattern() throws IOException {
+            // Given
+            Files.createFile(tempDir.resolve("doc1.adoc"));
+            Files.createFile(tempDir.resolve("doc2.adoc"));
+            Files.createFile(tempDir.resolve("readme.txt"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("*.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(2, files.size());
+            List<String> fileNames = files.stream()
+                .map(p -> p.getFileName().toString())
+                .collect(Collectors.toList());
+            assertTrue(fileNames.contains("doc1.adoc"));
+            assertTrue(fileNames.contains("doc2.adoc"));
+        }
     }
     
-    @Test
-    @DisplayName("should find matching files in directory")
-    void shouldFindMatchingFilesInDirectory() throws IOException {
-        // Given
-        Files.createFile(tempDir.resolve("doc1.adoc"));
-        Files.createFile(tempDir.resolve("doc2.adoc"));
-        Files.createFile(tempDir.resolve("readme.txt"));
+    @Nested
+    @DisplayName("Ant patterns with **")
+    class AntPatternsWithDoubleWildcard {
         
-        CLIConfig config = CLIConfig.builder()
-            .input(tempDir)
-            .pattern("*.adoc")
-            .build();
+        @Test
+        @DisplayName("should find files recursively with **/*.adoc")
+        void shouldFindFilesRecursivelyWithDoubleWildcard() throws IOException {
+            // Given
+            Path subDir = tempDir.resolve("subdir");
+            Path deepDir = subDir.resolve("deep");
+            Files.createDirectories(deepDir);
+            
+            Files.createFile(tempDir.resolve("root.adoc"));
+            Files.createFile(subDir.resolve("sub.adoc"));
+            Files.createFile(deepDir.resolve("deep.adoc"));
+            Files.createFile(tempDir.resolve("readme.txt"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("**/*.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(3, files.size());
+            List<String> relativePaths = files.stream()
+                .map(p -> tempDir.relativize(p).toString())
+                .collect(Collectors.toList());
+            assertTrue(relativePaths.contains("root.adoc"));
+            assertTrue(relativePaths.contains("subdir/sub.adoc".replace('/', java.io.File.separatorChar)));
+            assertTrue(relativePaths.contains("subdir/deep/deep.adoc".replace('/', java.io.File.separatorChar)));
+        }
         
-        // When
-        List<Path> files = service.discoverFiles(config);
-        
-        // Then
-        assertEquals(2, files.size());
-        assertTrue(files.stream().anyMatch(p -> p.getFileName().toString().equals("doc1.adoc")));
-        assertTrue(files.stream().anyMatch(p -> p.getFileName().toString().equals("doc2.adoc")));
+        @Test
+        @DisplayName("should find files in specific subdirectories with docs/**/*.adoc")
+        void shouldFindFilesInSpecificSubdirectories() throws IOException {
+            // Given
+            Path docsDir = tempDir.resolve("docs");
+            Path srcDir = tempDir.resolve("src");
+            Path docsSubDir = docsDir.resolve("api");
+            Files.createDirectories(docsSubDir);
+            Files.createDirectories(srcDir);
+            
+            Files.createFile(tempDir.resolve("root.adoc"));
+            Files.createFile(docsDir.resolve("manual.adoc"));
+            Files.createFile(docsSubDir.resolve("api.adoc"));
+            Files.createFile(srcDir.resolve("code.adoc"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("docs/**/*.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(2, files.size());
+            List<String> relativePaths = files.stream()
+                .map(p -> tempDir.relativize(p).toString())
+                .collect(Collectors.toList());
+            assertTrue(relativePaths.contains("docs/manual.adoc".replace('/', java.io.File.separatorChar)));
+            assertTrue(relativePaths.contains("docs/api/api.adoc".replace('/', java.io.File.separatorChar)));
+            assertFalse(relativePaths.contains("root.adoc"));
+            assertFalse(relativePaths.contains("src/code.adoc".replace('/', java.io.File.separatorChar)));
+        }
     }
     
-    @Test
-    @DisplayName("should find files recursively")
-    void shouldFindFilesRecursively() throws IOException {
-        // Given
-        Path subDir = tempDir.resolve("subdir");
-        Files.createDirectory(subDir);
-        Files.createFile(tempDir.resolve("root.adoc"));
-        Files.createFile(subDir.resolve("nested.adoc"));
+    @Nested
+    @DisplayName("Multiple patterns")
+    class MultiplePatterns {
         
-        CLIConfig config = CLIConfig.builder()
-            .input(tempDir)
-            .pattern("*.adoc")
-            .recursive(true)
-            .build();
+        @Test
+        @DisplayName("should combine results from multiple patterns")
+        void shouldCombineResultsFromMultiplePatterns() throws IOException {
+            // Given
+            Files.createFile(tempDir.resolve("README.adoc"));
+            Files.createFile(tempDir.resolve("guide.asciidoc"));
+            Files.createFile(tempDir.resolve("manual.txt"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("*.adoc", "*.asciidoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(2, files.size());
+            List<String> fileNames = files.stream()
+                .map(p -> p.getFileName().toString())
+                .collect(Collectors.toList());
+            assertTrue(fileNames.contains("README.adoc"));
+            assertTrue(fileNames.contains("guide.asciidoc"));
+        }
         
-        // When
-        List<Path> files = service.discoverFiles(config);
+        @Test
+        @DisplayName("should remove duplicates when patterns overlap")
+        void shouldRemoveDuplicatesWhenPatternsOverlap() throws IOException {
+            // Given
+            Files.createFile(tempDir.resolve("doc.adoc"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("*.adoc", "doc.*", "**/*.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(1, files.size());
+            assertEquals("doc.adoc", files.get(0).getFileName().toString());
+        }
         
-        // Then
-        assertEquals(2, files.size());
+        @Test
+        @DisplayName("should handle complex comma-separated patterns")
+        void shouldHandleComplexCommaSeparatedPatterns() throws IOException {
+            // Given
+            Path docsDir = tempDir.resolve("docs");
+            Path examplesDir = tempDir.resolve("examples");
+            Files.createDirectories(docsDir);
+            Files.createDirectories(examplesDir);
+            
+            Files.createFile(tempDir.resolve("README.adoc"));
+            Files.createFile(docsDir.resolve("guide.adoc"));
+            Files.createFile(examplesDir.resolve("example.asciidoc"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("docs/**/*.adoc", "examples/**/*.asciidoc", "README.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(3, files.size());
+        }
     }
     
-    @Test
-    @DisplayName("should not find files recursively when disabled")
-    void shouldNotFindFilesRecursivelyWhenDisabled() throws IOException {
-        // Given
-        Path subDir = tempDir.resolve("subdir");
-        Files.createDirectory(subDir);
-        Files.createFile(tempDir.resolve("root.adoc"));
-        Files.createFile(subDir.resolve("nested.adoc"));
+    @Nested
+    @DisplayName("Pattern matching")
+    class PatternMatching {
         
-        CLIConfig config = CLIConfig.builder()
-            .input(tempDir)
-            .pattern("*.adoc")
-            .recursive(false)
-            .build();
+        @Test
+        @DisplayName("should match single character wildcard (?)")
+        void shouldMatchSingleCharacterWildcard() throws IOException {
+            // Given
+            Files.createFile(tempDir.resolve("doc1.adoc"));
+            Files.createFile(tempDir.resolve("doc2.adoc"));
+            Files.createFile(tempDir.resolve("docs.adoc"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("doc?.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(3, files.size());
+            List<String> fileNames = files.stream()
+                .map(p -> p.getFileName().toString())
+                .collect(Collectors.toList());
+            assertTrue(fileNames.contains("doc1.adoc"));
+            assertTrue(fileNames.contains("doc2.adoc"));
+            assertTrue(fileNames.contains("docs.adoc")); // ? matches exactly one character, so 's' is matched
+        }
         
-        // When
-        List<Path> files = service.discoverFiles(config);
-        
-        // Then
-        assertEquals(1, files.size());
-        assertEquals("root.adoc", files.get(0).getFileName().toString());
+        @Test
+        @DisplayName("should handle patterns with directory wildcards")
+        void shouldHandlePatternsWithDirectoryWildcards() throws IOException {
+            // Given
+            Path moduleA = tempDir.resolve("module-a").resolve("docs");
+            Path moduleB = tempDir.resolve("module-b").resolve("docs");
+            Files.createDirectories(moduleA);
+            Files.createDirectories(moduleB);
+            
+            Files.createFile(moduleA.resolve("guide.adoc"));
+            Files.createFile(moduleB.resolve("guide.adoc"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("module-*/docs/*.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(2, files.size());
+        }
     }
     
-    @Test
-    @DisplayName("should handle custom patterns")
-    void shouldHandleCustomPatterns() throws IOException {
-        // Given
-        Files.createFile(tempDir.resolve("doc.adoc"));
-        Files.createFile(tempDir.resolve("manual.asciidoc"));
-        Files.createFile(tempDir.resolve("readme.asc"));
+    @Nested
+    @DisplayName("Edge cases")
+    class EdgeCases {
         
-        CLIConfig config = CLIConfig.builder()
-            .input(tempDir)
-            .pattern("*.asciidoc")
-            .build();
+        @Test
+        @DisplayName("should return empty list when no files match")
+        void shouldReturnEmptyListWhenNoFilesMatch() throws IOException {
+            // Given
+            Files.createFile(tempDir.resolve("readme.txt"));
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("*.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertTrue(files.isEmpty());
+        }
         
-        // When
-        List<Path> files = service.discoverFiles(config);
+        @Test
+        @DisplayName("should handle absolute paths")
+        void shouldHandleAbsolutePaths() throws IOException {
+            // Given
+            Path file = tempDir.resolve("test.adoc");
+            Files.createFile(file);
+            
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList(file.toAbsolutePath().toString()))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertEquals(1, files.size());
+            assertEquals(file.normalize(), files.get(0));
+        }
         
-        // Then
-        assertEquals(1, files.size());
-        assertEquals("manual.asciidoc", files.get(0).getFileName().toString());
-    }
-    
-    @Test
-    @DisplayName("should throw exception for non-existent input")
-    void shouldThrowExceptionForNonExistentInput() {
-        // Given
-        Path nonExistent = tempDir.resolve("non-existent");
-        CLIConfig config = CLIConfig.builder()
-            .input(nonExistent)
-            .build();
-        
-        // When/Then
-        assertThrows(IOException.class, () -> service.discoverFiles(config));
-    }
-    
-    @Test
-    @DisplayName("should return empty list when no files match")
-    void shouldReturnEmptyListWhenNoFilesMatch() throws IOException {
-        // Given
-        Files.createFile(tempDir.resolve("readme.txt"));
-        
-        CLIConfig config = CLIConfig.builder()
-            .input(tempDir)
-            .pattern("*.adoc")
-            .build();
-        
-        // When
-        List<Path> files = service.discoverFiles(config);
-        
-        // Then
-        assertTrue(files.isEmpty());
+        @Test
+        @DisplayName("should handle empty directory")
+        void shouldHandleEmptyDirectory() throws IOException {
+            // Given
+            CLIConfig config = CLIConfig.builder()
+                .inputPatterns(Arrays.asList("**/*.adoc"))
+                .baseDirectory(tempDir)
+                .build();
+            
+            // When
+            List<Path> files = service.discoverFiles(config);
+            
+            // Then
+            assertTrue(files.isEmpty());
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Enhanced `--input` option to accept comma-separated Ant patterns
- Removed deprecated `--pattern`, `--recursive` and `--no-recursive` options  
- Added Apache Commons IO dependency for advanced pattern matching
- Implemented comprehensive Ant pattern support (**, *, ?)

## Changes
1. **CLIConfig**: Refactored to store multiple input patterns instead of single path
2. **FileDiscoveryService**: Complete rewrite with Ant pattern matching
3. **CLIOptions**: Removed deprecated options
4. **LinterCLI**: Updated to parse comma-separated patterns and improved help text

## Examples
```bash
# Validate all AsciiDoc files recursively
java -jar linter.jar -i "**/*.adoc"

# Multiple patterns
java -jar linter.jar -i "docs/**/*.adoc,examples/**/*.asciidoc,README.adoc"

# Complex patterns
java -jar linter.jar -i "src/*/docs/**/*.adoc,test-*/**/*.adoc"
```

## Breaking Changes
- Removed `-p/--pattern` option
- Removed `-r/--recursive` and `--no-recursive` options
- Users must update their scripts to use the new Ant pattern syntax

Closes #34