### PR TITLE
#43 Add SIDEBAR block type support

### DIFF
--- a/docs/linter-config-specification.yaml
+++ b/docs/linter-config-specification.yaml
@@ -644,3 +644,29 @@ document:
             lines:
               min: 1
               max: 5                    # Kurze Beschreibungen
+        - sidebar:
+            name: "additional-info"          # Für ergänzende Informationen am Rand
+            severity: info                   # PFLICHT: Default-Severity für den gesamten Block
+            occurrence:
+              min: 0
+              max: 2                         # Nicht zu viele Sidebars
+              severity: warn
+            # Sidebar-spezifische Attribute
+            title:
+              required: false                # Titel optional
+              minLength: 5
+              maxLength: 50
+              pattern: "^[A-Z].*$"
+              severity: info
+            content:
+              required: true
+              minLength: 50                  # Sidebars sollten substantiell sein
+              maxLength: 800
+              lines:
+                min: 3
+                max: 30
+                severity: info
+            position:
+              required: false                # Position optional (left, right)
+              allowed: ["left", "right", "float"]
+              severity: info

--- a/src/main/java/com/example/linter/config/BlockType.java
+++ b/src/main/java/com/example/linter/config/BlockType.java
@@ -11,7 +11,8 @@ public enum BlockType {
     VERSE,
     ADMONITION,
     PASS,
-    LITERAL;
+    LITERAL,
+    SIDEBAR;
     
     @JsonValue
     public String toValue() {
@@ -30,6 +31,7 @@ public enum BlockType {
             case "admonition" -> ADMONITION;
             case "pass" -> PASS;
             case "literal" -> LITERAL;
+            case "sidebar" -> SIDEBAR;
             default -> throw new IllegalArgumentException("Unknown block type: " + value);
         };
     }

--- a/src/main/java/com/example/linter/config/blocks/SidebarBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/SidebarBlock.java
@@ -1,0 +1,442 @@
+package com.example.linter.config.blocks;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+/**
+ * Configuration for sidebar blocks in AsciiDoc.
+ * Sidebar blocks are used for supplementary information displayed alongside the main content.
+ * 
+ * <p>Example usage:
+ * <pre>
+ * ****
+ * Sidebar content here
+ * ****
+ * </pre>
+ * 
+ * <p>Validation is based on the YAML schema configuration for sidebar blocks.
+ */
+@JsonDeserialize(builder = SidebarBlock.Builder.class)
+public final class SidebarBlock extends AbstractBlock {
+    @JsonProperty("title")
+    private final TitleConfig title;
+    @JsonProperty("content")
+    private final ContentConfig content;
+    @JsonProperty("position")
+    private final PositionConfig position;
+    
+    private SidebarBlock(Builder builder) {
+        super(builder);
+        this.title = builder.title;
+        this.content = builder.content;
+        this.position = builder.position;
+    }
+    
+    @Override
+    public BlockType getType() {
+        return BlockType.SIDEBAR;
+    }
+    
+    public TitleConfig getTitle() {
+        return title;
+    }
+    
+    public ContentConfig getContent() {
+        return content;
+    }
+    
+    public PositionConfig getPosition() {
+        return position;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    @JsonDeserialize(builder = TitleConfig.TitleConfigBuilder.class)
+    public static class TitleConfig {
+        @JsonProperty("required")
+        private final boolean required;
+        @JsonProperty("minLength")
+        private final Integer minLength;
+        @JsonProperty("maxLength")
+        private final Integer maxLength;
+        @JsonProperty("pattern")
+        private final Pattern pattern;
+        @JsonProperty("severity")
+        private final Severity severity;
+        
+        private TitleConfig(TitleConfigBuilder builder) {
+            this.required = builder.required;
+            this.minLength = builder.minLength;
+            this.maxLength = builder.maxLength;
+            this.pattern = builder.pattern;
+            this.severity = builder.severity;
+        }
+        
+        public boolean isRequired() {
+            return required;
+        }
+        
+        public Integer getMinLength() {
+            return minLength;
+        }
+        
+        public Integer getMaxLength() {
+            return maxLength;
+        }
+        
+        public Pattern getPattern() {
+            return pattern;
+        }
+        
+        public Severity getSeverity() {
+            return severity;
+        }
+        
+        public static TitleConfigBuilder builder() {
+            return new TitleConfigBuilder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class TitleConfigBuilder {
+            private boolean required;
+            private Integer minLength;
+            private Integer maxLength;
+            private Pattern pattern;
+            private Severity severity;
+            
+            public TitleConfigBuilder required(boolean required) {
+                this.required = required;
+                return this;
+            }
+            
+            public TitleConfigBuilder minLength(Integer minLength) {
+                this.minLength = minLength;
+                return this;
+            }
+            
+            public TitleConfigBuilder maxLength(Integer maxLength) {
+                this.maxLength = maxLength;
+                return this;
+            }
+            
+            public TitleConfigBuilder pattern(String pattern) {
+                this.pattern = pattern != null ? Pattern.compile(pattern) : null;
+                return this;
+            }
+            
+            public TitleConfigBuilder pattern(Pattern pattern) {
+                this.pattern = pattern;
+                return this;
+            }
+            
+            public TitleConfigBuilder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public TitleConfig build() {
+                return new TitleConfig(this);
+            }
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof TitleConfig that)) return false;
+            return required == that.required &&
+                   Objects.equals(minLength, that.minLength) &&
+                   Objects.equals(maxLength, that.maxLength) &&
+                   Objects.equals(pattern != null ? pattern.pattern() : null, 
+                                that.pattern != null ? that.pattern.pattern() : null) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, minLength, maxLength, 
+                              pattern != null ? pattern.pattern() : null, severity);
+        }
+    }
+    
+    @JsonDeserialize(builder = ContentConfig.ContentConfigBuilder.class)
+    public static class ContentConfig {
+        @JsonProperty("required")
+        private final boolean required;
+        @JsonProperty("minLength")
+        private final Integer minLength;
+        @JsonProperty("maxLength")
+        private final Integer maxLength;
+        @JsonProperty("lines")
+        private final LinesConfig lines;
+        
+        private ContentConfig(ContentConfigBuilder builder) {
+            this.required = builder.required;
+            this.minLength = builder.minLength;
+            this.maxLength = builder.maxLength;
+            this.lines = builder.lines;
+        }
+        
+        public boolean isRequired() {
+            return required;
+        }
+        
+        public Integer getMinLength() {
+            return minLength;
+        }
+        
+        public Integer getMaxLength() {
+            return maxLength;
+        }
+        
+        public LinesConfig getLines() {
+            return lines;
+        }
+        
+        public static ContentConfigBuilder builder() {
+            return new ContentConfigBuilder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class ContentConfigBuilder {
+            private boolean required;
+            private Integer minLength;
+            private Integer maxLength;
+            private LinesConfig lines;
+            
+            public ContentConfigBuilder required(boolean required) {
+                this.required = required;
+                return this;
+            }
+            
+            public ContentConfigBuilder minLength(Integer minLength) {
+                this.minLength = minLength;
+                return this;
+            }
+            
+            public ContentConfigBuilder maxLength(Integer maxLength) {
+                this.maxLength = maxLength;
+                return this;
+            }
+            
+            public ContentConfigBuilder lines(LinesConfig lines) {
+                this.lines = lines;
+                return this;
+            }
+            
+            public ContentConfig build() {
+                return new ContentConfig(this);
+            }
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ContentConfig that)) return false;
+            return required == that.required &&
+                   Objects.equals(minLength, that.minLength) &&
+                   Objects.equals(maxLength, that.maxLength) &&
+                   Objects.equals(lines, that.lines);
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, minLength, maxLength, lines);
+        }
+    }
+    
+    @JsonDeserialize(builder = LinesConfig.LinesConfigBuilder.class)
+    public static class LinesConfig {
+        @JsonProperty("min")
+        private final Integer min;
+        @JsonProperty("max")
+        private final Integer max;
+        @JsonProperty("severity")
+        private final Severity severity;
+        
+        private LinesConfig(LinesConfigBuilder builder) {
+            this.min = builder.min;
+            this.max = builder.max;
+            this.severity = builder.severity;
+        }
+        
+        public Integer getMin() {
+            return min;
+        }
+        
+        public Integer getMax() {
+            return max;
+        }
+        
+        public Severity getSeverity() {
+            return severity;
+        }
+        
+        public static LinesConfigBuilder builder() {
+            return new LinesConfigBuilder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class LinesConfigBuilder {
+            private Integer min;
+            private Integer max;
+            private Severity severity;
+            
+            public LinesConfigBuilder min(Integer min) {
+                this.min = min;
+                return this;
+            }
+            
+            public LinesConfigBuilder max(Integer max) {
+                this.max = max;
+                return this;
+            }
+            
+            public LinesConfigBuilder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public LinesConfig build() {
+                return new LinesConfig(this);
+            }
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof LinesConfig that)) return false;
+            return Objects.equals(min, that.min) &&
+                   Objects.equals(max, that.max) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(min, max, severity);
+        }
+    }
+    
+    @JsonDeserialize(builder = PositionConfig.PositionConfigBuilder.class)
+    public static class PositionConfig {
+        @JsonProperty("required")
+        private final boolean required;
+        @JsonProperty("allowed")
+        private final List<String> allowed;
+        @JsonProperty("severity")
+        private final Severity severity;
+        
+        private PositionConfig(PositionConfigBuilder builder) {
+            this.required = builder.required;
+            this.allowed = builder.allowed;
+            this.severity = builder.severity;
+        }
+        
+        public boolean isRequired() {
+            return required;
+        }
+        
+        public List<String> getAllowed() {
+            return allowed;
+        }
+        
+        public Severity getSeverity() {
+            return severity;
+        }
+        
+        public static PositionConfigBuilder builder() {
+            return new PositionConfigBuilder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class PositionConfigBuilder {
+            private boolean required;
+            private List<String> allowed;
+            private Severity severity;
+            
+            public PositionConfigBuilder required(boolean required) {
+                this.required = required;
+                return this;
+            }
+            
+            public PositionConfigBuilder allowed(List<String> allowed) {
+                this.allowed = allowed;
+                return this;
+            }
+            
+            public PositionConfigBuilder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public PositionConfig build() {
+                return new PositionConfig(this);
+            }
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof PositionConfig that)) return false;
+            return required == that.required &&
+                   Objects.equals(allowed, that.allowed) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, allowed, severity);
+        }
+    }
+    
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends AbstractBuilder<Builder> {
+        private TitleConfig title;
+        private ContentConfig content;
+        private PositionConfig position;
+        
+        public Builder title(TitleConfig title) {
+            this.title = title;
+            return this;
+        }
+        
+        public Builder content(ContentConfig content) {
+            this.content = content;
+            return this;
+        }
+        
+        public Builder position(PositionConfig position) {
+            this.position = position;
+            return this;
+        }
+        
+        @Override
+        public SidebarBlock build() {
+            Objects.requireNonNull(severity, "severity is required");
+            return new SidebarBlock(this);
+        }
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SidebarBlock that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(title, that.title) &&
+               Objects.equals(content, that.content) &&
+               Objects.equals(position, that.position);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), title, content, position);
+    }
+}

--- a/src/main/java/com/example/linter/config/loader/BlockListDeserializer.java
+++ b/src/main/java/com/example/linter/config/loader/BlockListDeserializer.java
@@ -12,6 +12,7 @@ import com.example.linter.config.blocks.ListingBlock;
 import com.example.linter.config.blocks.LiteralBlock;
 import com.example.linter.config.blocks.ParagraphBlock;
 import com.example.linter.config.blocks.PassBlock;
+import com.example.linter.config.blocks.SidebarBlock;
 import com.example.linter.config.blocks.TableBlock;
 import com.example.linter.config.blocks.VerseBlock;
 import com.fasterxml.jackson.core.JsonParser;
@@ -74,6 +75,7 @@ public class BlockListDeserializer extends JsonDeserializer<List<Block>> {
                 case ADMONITION -> mapper.treeToValue(blockData, AdmonitionBlock.class);
                 case PASS -> mapper.treeToValue(blockData, PassBlock.class);
                 case LITERAL -> mapper.treeToValue(blockData, LiteralBlock.class);
+                case SIDEBAR -> mapper.treeToValue(blockData, SidebarBlock.class);
             };
             
             blocks.add(block);

--- a/src/main/java/com/example/linter/validator/block/BlockTypeDetector.java
+++ b/src/main/java/com/example/linter/validator/block/BlockTypeDetector.java
@@ -54,8 +54,10 @@ public final class BlockTypeDetector {
             case "pass":
                 return BlockType.PASS;
                 
-            case "example":
             case "sidebar":
+                return BlockType.SIDEBAR;
+                
+            case "example":
             case "open":
                 // These could contain other blocks, check content
                 return detectFromContent(node);

--- a/src/main/java/com/example/linter/validator/block/BlockValidatorFactory.java
+++ b/src/main/java/com/example/linter/validator/block/BlockValidatorFactory.java
@@ -52,6 +52,7 @@ public final class BlockValidatorFactory {
         registerValidator(map, new AdmonitionBlockValidator());
         registerValidator(map, new PassBlockValidator());
         registerValidator(map, new LiteralBlockValidator());
+        registerValidator(map, new SidebarBlockValidator());
         
         return map;
     }

--- a/src/main/java/com/example/linter/validator/block/SidebarBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/SidebarBlockValidator.java
@@ -1,0 +1,258 @@
+package com.example.linter.validator.block;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.asciidoctor.ast.StructuralNode;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.config.blocks.SidebarBlock;
+import com.example.linter.validator.ValidationMessage;
+
+/**
+ * Validator for sidebar blocks based on YAML schema configuration.
+ * 
+ * <p>Sidebar blocks in AsciiDoc are delimited by **** and contain supplementary information.
+ * This validator checks:
+ * <ul>
+ *   <li>Title requirements (optional with pattern, minLength, maxLength)</li>
+ *   <li>Content requirements (required with minLength, maxLength, nested lines)</li>
+ *   <li>Position requirements (optional with allowed values)</li>
+ * </ul>
+ * 
+ * <p>Each nested configuration can optionally define its own severity level.
+ * If not specified, the block-level severity is used as fallback.</p>
+ * 
+ * @see SidebarBlock
+ * @see BlockTypeValidator
+ */
+public final class SidebarBlockValidator implements BlockTypeValidator {
+    
+    @Override
+    public BlockType getSupportedType() {
+        return BlockType.SIDEBAR;
+    }
+    
+    @Override
+    public List<ValidationMessage> validate(StructuralNode block, 
+                                          Block config,
+                                          BlockValidationContext context) {
+        
+        SidebarBlock sidebarConfig = (SidebarBlock) config;
+        List<ValidationMessage> messages = new ArrayList<>();
+        
+        // Validate title
+        if (sidebarConfig.getTitle() != null) {
+            validateTitle(block, sidebarConfig, context, messages);
+        }
+        
+        // Validate content
+        if (sidebarConfig.getContent() != null) {
+            validateContent(block, sidebarConfig, context, messages);
+        }
+        
+        // Validate position
+        if (sidebarConfig.getPosition() != null) {
+            validatePosition(block, sidebarConfig, context, messages);
+        }
+        
+        return messages;
+    }
+    
+    private void validateTitle(StructuralNode block, SidebarBlock config,
+                             BlockValidationContext context, List<ValidationMessage> messages) {
+        SidebarBlock.TitleConfig titleConfig = config.getTitle();
+        
+        String title = block.getTitle();
+        boolean hasTitle = title != null && !title.trim().isEmpty();
+        
+        // Get severity with fallback to block severity
+        Severity severity = titleConfig.getSeverity() != null ? titleConfig.getSeverity() : config.getSeverity();
+        
+        // Check if title is required
+        if (titleConfig.isRequired() && !hasTitle) {
+            messages.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("sidebar.title.required")
+                .location(context.createLocation(block))
+                .message("Sidebar block requires a title")
+                .actualValue("No title")
+                .expectedValue("Title required")
+                .build());
+            return;
+        }
+        
+        if (!hasTitle) {
+            return;
+        }
+        
+        // Validate title length
+        if (titleConfig.getMinLength() != null && title.length() < titleConfig.getMinLength()) {
+            messages.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("sidebar.title.minLength")
+                .location(context.createLocation(block))
+                .message("Sidebar title too short")
+                .actualValue(title.length() + " characters")
+                .expectedValue("At least " + titleConfig.getMinLength() + " characters")
+                .build());
+        }
+        
+        if (titleConfig.getMaxLength() != null && title.length() > titleConfig.getMaxLength()) {
+            messages.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("sidebar.title.maxLength")
+                .location(context.createLocation(block))
+                .message("Sidebar title too long")
+                .actualValue(title.length() + " characters")
+                .expectedValue("At most " + titleConfig.getMaxLength() + " characters")
+                .build());
+        }
+        
+        // Validate title pattern
+        if (titleConfig.getPattern() != null) {
+            Pattern pattern = titleConfig.getPattern();
+            if (!pattern.matcher(title).matches()) {
+                messages.add(ValidationMessage.builder()
+                    .severity(severity)
+                    .ruleId("sidebar.title.pattern")
+                    .location(context.createLocation(block))
+                    .message("Sidebar title does not match required pattern")
+                    .actualValue(title)
+                    .expectedValue("Pattern: " + pattern.pattern())
+                    .build());
+            }
+        }
+    }
+    
+    private void validateContent(StructuralNode block, SidebarBlock config,
+                               BlockValidationContext context, List<ValidationMessage> messages) {
+        SidebarBlock.ContentConfig contentConfig = config.getContent();
+        
+        String content = block.getContent() != null ? block.getContent().toString() : "";
+        
+        // Check if content is required
+        if (contentConfig.isRequired() && content.isEmpty()) {
+            messages.add(ValidationMessage.builder()
+                .severity(config.getSeverity())
+                .ruleId("sidebar.content.required")
+                .location(context.createLocation(block))
+                .message("Sidebar block requires content")
+                .actualValue("No content")
+                .expectedValue("Content required")
+                .build());
+            return;
+        }
+        
+        if (content.isEmpty()) {
+            return;
+        }
+        
+        // Validate content length
+        if (contentConfig.getMinLength() != null && content.length() < contentConfig.getMinLength()) {
+            messages.add(ValidationMessage.builder()
+                .severity(config.getSeverity())
+                .ruleId("sidebar.content.minLength")
+                .location(context.createLocation(block))
+                .message("Sidebar content too short")
+                .actualValue(content.length() + " characters")
+                .expectedValue("At least " + contentConfig.getMinLength() + " characters")
+                .build());
+        }
+        
+        if (contentConfig.getMaxLength() != null && content.length() > contentConfig.getMaxLength()) {
+            messages.add(ValidationMessage.builder()
+                .severity(config.getSeverity())
+                .ruleId("sidebar.content.maxLength")
+                .location(context.createLocation(block))
+                .message("Sidebar content too long")
+                .actualValue(content.length() + " characters")
+                .expectedValue("At most " + contentConfig.getMaxLength() + " characters")
+                .build());
+        }
+        
+        // Validate lines if configured
+        if (contentConfig.getLines() != null) {
+            validateLines(block, config, contentConfig.getLines(), context, messages);
+        }
+    }
+    
+    private void validateLines(StructuralNode block, SidebarBlock config, 
+                             SidebarBlock.LinesConfig linesConfig,
+                             BlockValidationContext context, List<ValidationMessage> messages) {
+        
+        String content = block.getContent() != null ? block.getContent().toString() : "";
+        String[] lines = content.split("\n");
+        int lineCount = lines.length;
+        
+        // Get severity with fallback to block severity
+        Severity severity = linesConfig.getSeverity() != null ? linesConfig.getSeverity() : config.getSeverity();
+        
+        // Validate minimum lines
+        if (linesConfig.getMin() != null && lineCount < linesConfig.getMin()) {
+            messages.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("sidebar.lines.min")
+                .location(context.createLocation(block))
+                .message("Sidebar has too few lines")
+                .actualValue(lineCount + " lines")
+                .expectedValue("At least " + linesConfig.getMin() + " lines")
+                .build());
+        }
+        
+        // Validate maximum lines
+        if (linesConfig.getMax() != null && lineCount > linesConfig.getMax()) {
+            messages.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("sidebar.lines.max")
+                .location(context.createLocation(block))
+                .message("Sidebar has too many lines")
+                .actualValue(lineCount + " lines")
+                .expectedValue("At most " + linesConfig.getMax() + " lines")
+                .build());
+        }
+    }
+    
+    private void validatePosition(StructuralNode block, SidebarBlock config,
+                                BlockValidationContext context, List<ValidationMessage> messages) {
+        SidebarBlock.PositionConfig positionConfig = config.getPosition();
+        
+        // Get position attribute
+        Object positionAttr = block.getAttribute("position");
+        String position = positionAttr != null ? positionAttr.toString() : null;
+        
+        // Get severity with fallback to block severity
+        Severity severity = positionConfig.getSeverity() != null ? positionConfig.getSeverity() : config.getSeverity();
+        
+        // Check if position is required
+        if (positionConfig.isRequired() && (position == null || position.isEmpty())) {
+            messages.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("sidebar.position.required")
+                .location(context.createLocation(block))
+                .message("Sidebar block requires a position attribute")
+                .actualValue("No position attribute")
+                .expectedValue("Position attribute required")
+                .build());
+            return;
+        }
+        
+        // Validate allowed positions
+        if (position != null && !position.isEmpty() && 
+            positionConfig.getAllowed() != null && !positionConfig.getAllowed().isEmpty()) {
+            if (!positionConfig.getAllowed().contains(position)) {
+                messages.add(ValidationMessage.builder()
+                    .severity(severity)
+                    .ruleId("sidebar.position.allowed")
+                    .location(context.createLocation(block))
+                    .message("Invalid sidebar position")
+                    .actualValue(position)
+                    .expectedValue("One of: " + String.join(", ", positionConfig.getAllowed()))
+                    .build());
+            }
+        }
+    }
+}

--- a/src/main/resources/schemas/blocks/sidebar-block-schema.json
+++ b/src/main/resources/schemas/blocks/sidebar-block-schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "sidebar-block-schema.json",
+  "title": "Sidebar Block Configuration",
+  "description": "Configuration for sidebar blocks in AsciiDoc. Sidebars are used for supplementary information displayed alongside the main content.",
+  "type": "object",
+  "required": ["severity"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name identifier for this block configuration"
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["error", "warn", "info"],
+      "description": "Default severity level for validation issues"
+    },
+    "occurrence": {
+      "$ref": "../common/occurrence-config-schema.json"
+    },
+    "title": {
+      "type": "object",
+      "description": "Title configuration for sidebar blocks",
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Whether a title is required"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum length for the title"
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum length for the title"
+        },
+        "pattern": {
+          "type": "string",
+          "description": "Regular expression pattern that the title must match"
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warn", "info"],
+          "description": "Severity level for title validation issues (overrides block-level severity)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "content": {
+      "type": "object",
+      "description": "Content configuration for sidebar blocks",
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Whether content is required"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum length for the content"
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum length for the content"
+        },
+        "lines": {
+          "type": "object",
+          "description": "Line count configuration",
+          "properties": {
+            "min": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Minimum number of lines"
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Maximum number of lines"
+            },
+            "severity": {
+              "type": "string",
+              "enum": ["error", "warn", "info"],
+              "description": "Severity level for line count validation issues"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "position": {
+      "type": "object",
+      "description": "Position configuration for sidebar blocks",
+      "properties": {
+        "required": {
+          "type": "boolean",
+          "description": "Whether a position attribute is required"
+        },
+        "allowed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of allowed position values (e.g., left, right, float)"
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warn", "info"],
+          "description": "Severity level for position validation issues"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/java/com/example/linter/config/blocks/SidebarBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/SidebarBlockTest.java
@@ -1,0 +1,416 @@
+package com.example.linter.config.blocks;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("SidebarBlock")
+class SidebarBlockTest {
+    
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTest {
+        
+        @Test
+        @DisplayName("should build with required fields")
+        void shouldBuildWithRequiredFields() {
+            // Given
+            String name = "sidebar-test";
+            Severity severity = Severity.WARN;
+            
+            // When
+            SidebarBlock block = SidebarBlock.builder()
+                .name(name)
+                .severity(severity)
+                .build();
+            
+            // Then
+            assertEquals(name, block.getName());
+            assertEquals(severity, block.getSeverity());
+            assertEquals(BlockType.SIDEBAR, block.getType());
+            assertNull(block.getTitle());
+            assertNull(block.getContent());
+            assertNull(block.getPosition());
+        }
+        
+        @Test
+        @DisplayName("should build with all fields")
+        void shouldBuildWithAllFields() {
+            // Given
+            String name = "sidebar-full";
+            Severity severity = Severity.ERROR;
+            SidebarBlock.TitleConfig title = SidebarBlock.TitleConfig.builder()
+                .required(true)
+                .minLength(5)
+                .maxLength(50)
+                .pattern("^[A-Z].*$")
+                .severity(Severity.INFO)
+                .build();
+            SidebarBlock.ContentConfig content = SidebarBlock.ContentConfig.builder()
+                .required(true)
+                .minLength(50)
+                .maxLength(800)
+                .lines(SidebarBlock.LinesConfig.builder()
+                    .min(3)
+                    .max(30)
+                    .severity(Severity.INFO)
+                    .build())
+                .build();
+            SidebarBlock.PositionConfig position = SidebarBlock.PositionConfig.builder()
+                .required(false)
+                .allowed(List.of("left", "right", "float"))
+                .severity(Severity.INFO)
+                .build();
+            
+            // When
+            SidebarBlock block = SidebarBlock.builder()
+                .name(name)
+                .severity(severity)
+                .title(title)
+                .content(content)
+                .position(position)
+                .build();
+            
+            // Then
+            assertEquals(name, block.getName());
+            assertEquals(severity, block.getSeverity());
+            assertEquals(title, block.getTitle());
+            assertEquals(content, block.getContent());
+            assertEquals(position, block.getPosition());
+        }
+        
+        @Test
+        @DisplayName("should require severity")
+        void shouldRequireSeverity() {
+            // When/Then
+            assertThrows(NullPointerException.class, () ->
+                SidebarBlock.builder()
+                    .name("test")
+                    .build(),
+                "severity is required"
+            );
+        }
+    }
+    
+    @Nested
+    @DisplayName("TitleConfig")
+    class TitleConfigTest {
+        
+        @Test
+        @DisplayName("should build with all fields")
+        void shouldBuildWithAllFields() {
+            // Given
+            boolean required = true;
+            Integer minLength = 10;
+            Integer maxLength = 100;
+            String patternStr = "^[A-Z].*$";
+            Pattern pattern = Pattern.compile(patternStr);
+            Severity severity = Severity.WARN;
+            
+            // When
+            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder()
+                .required(required)
+                .minLength(minLength)
+                .maxLength(maxLength)
+                .pattern(pattern)
+                .severity(severity)
+                .build();
+            
+            // Then
+            assertEquals(required, config.isRequired());
+            assertEquals(minLength, config.getMinLength());
+            assertEquals(maxLength, config.getMaxLength());
+            assertEquals(pattern.pattern(), config.getPattern().pattern());
+            assertEquals(severity, config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should build with pattern string")
+        void shouldBuildWithPatternString() {
+            // Given
+            String patternStr = "^[A-Z].*$";
+            
+            // When
+            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder()
+                .pattern(patternStr)
+                .build();
+            
+            // Then
+            assertNotNull(config.getPattern());
+            assertEquals(patternStr, config.getPattern().pattern());
+        }
+        
+        @Test
+        @DisplayName("should handle null pattern string")
+        void shouldHandleNullPatternString() {
+            // When
+            SidebarBlock.TitleConfig config = SidebarBlock.TitleConfig.builder()
+                .pattern((String) null)
+                .build();
+            
+            // Then
+            assertNull(config.getPattern());
+        }
+        
+        @Test
+        @DisplayName("should implement equals and hashCode")
+        void shouldImplementEqualsAndHashCode() {
+            // Given
+            SidebarBlock.TitleConfig config1 = SidebarBlock.TitleConfig.builder()
+                .required(true)
+                .minLength(5)
+                .maxLength(50)
+                .pattern("^[A-Z].*$")
+                .severity(Severity.INFO)
+                .build();
+            
+            SidebarBlock.TitleConfig config2 = SidebarBlock.TitleConfig.builder()
+                .required(true)
+                .minLength(5)
+                .maxLength(50)
+                .pattern("^[A-Z].*$")
+                .severity(Severity.INFO)
+                .build();
+            
+            SidebarBlock.TitleConfig config3 = SidebarBlock.TitleConfig.builder()
+                .required(false)
+                .minLength(5)
+                .maxLength(50)
+                .pattern("^[A-Z].*$")
+                .severity(Severity.INFO)
+                .build();
+            
+            // Then
+            assertEquals(config1, config2);
+            assertEquals(config1.hashCode(), config2.hashCode());
+            assertNotEquals(config1, config3);
+        }
+    }
+    
+    @Nested
+    @DisplayName("ContentConfig")
+    class ContentConfigTest {
+        
+        @Test
+        @DisplayName("should build with all fields")
+        void shouldBuildWithAllFields() {
+            // Given
+            boolean required = true;
+            Integer minLength = 50;
+            Integer maxLength = 800;
+            SidebarBlock.LinesConfig lines = SidebarBlock.LinesConfig.builder()
+                .min(3)
+                .max(30)
+                .severity(Severity.INFO)
+                .build();
+            
+            // When
+            SidebarBlock.ContentConfig config = SidebarBlock.ContentConfig.builder()
+                .required(required)
+                .minLength(minLength)
+                .maxLength(maxLength)
+                .lines(lines)
+                .build();
+            
+            // Then
+            assertEquals(required, config.isRequired());
+            assertEquals(minLength, config.getMinLength());
+            assertEquals(maxLength, config.getMaxLength());
+            assertEquals(lines, config.getLines());
+        }
+        
+        @Test
+        @DisplayName("should implement equals and hashCode")
+        void shouldImplementEqualsAndHashCode() {
+            // Given
+            SidebarBlock.LinesConfig lines = SidebarBlock.LinesConfig.builder()
+                .min(3)
+                .max(30)
+                .build();
+            
+            SidebarBlock.ContentConfig config1 = SidebarBlock.ContentConfig.builder()
+                .required(true)
+                .minLength(50)
+                .maxLength(800)
+                .lines(lines)
+                .build();
+            
+            SidebarBlock.ContentConfig config2 = SidebarBlock.ContentConfig.builder()
+                .required(true)
+                .minLength(50)
+                .maxLength(800)
+                .lines(lines)
+                .build();
+            
+            SidebarBlock.ContentConfig config3 = SidebarBlock.ContentConfig.builder()
+                .required(false)
+                .minLength(50)
+                .maxLength(800)
+                .lines(lines)
+                .build();
+            
+            // Then
+            assertEquals(config1, config2);
+            assertEquals(config1.hashCode(), config2.hashCode());
+            assertNotEquals(config1, config3);
+        }
+    }
+    
+    @Nested
+    @DisplayName("LinesConfig")
+    class LinesConfigTest {
+        
+        @Test
+        @DisplayName("should build with all fields")
+        void shouldBuildWithAllFields() {
+            // Given
+            Integer min = 3;
+            Integer max = 30;
+            Severity severity = Severity.INFO;
+            
+            // When
+            SidebarBlock.LinesConfig config = SidebarBlock.LinesConfig.builder()
+                .min(min)
+                .max(max)
+                .severity(severity)
+                .build();
+            
+            // Then
+            assertEquals(min, config.getMin());
+            assertEquals(max, config.getMax());
+            assertEquals(severity, config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should implement equals and hashCode")
+        void shouldImplementEqualsAndHashCode() {
+            // Given
+            SidebarBlock.LinesConfig config1 = SidebarBlock.LinesConfig.builder()
+                .min(3)
+                .max(30)
+                .severity(Severity.INFO)
+                .build();
+            
+            SidebarBlock.LinesConfig config2 = SidebarBlock.LinesConfig.builder()
+                .min(3)
+                .max(30)
+                .severity(Severity.INFO)
+                .build();
+            
+            SidebarBlock.LinesConfig config3 = SidebarBlock.LinesConfig.builder()
+                .min(5)
+                .max(30)
+                .severity(Severity.INFO)
+                .build();
+            
+            // Then
+            assertEquals(config1, config2);
+            assertEquals(config1.hashCode(), config2.hashCode());
+            assertNotEquals(config1, config3);
+        }
+    }
+    
+    @Nested
+    @DisplayName("PositionConfig")
+    class PositionConfigTest {
+        
+        @Test
+        @DisplayName("should build with all fields")
+        void shouldBuildWithAllFields() {
+            // Given
+            boolean required = false;
+            List<String> allowed = List.of("left", "right", "float");
+            Severity severity = Severity.INFO;
+            
+            // When
+            SidebarBlock.PositionConfig config = SidebarBlock.PositionConfig.builder()
+                .required(required)
+                .allowed(allowed)
+                .severity(severity)
+                .build();
+            
+            // Then
+            assertEquals(required, config.isRequired());
+            assertEquals(allowed, config.getAllowed());
+            assertEquals(severity, config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should implement equals and hashCode")
+        void shouldImplementEqualsAndHashCode() {
+            // Given
+            List<String> allowed = List.of("left", "right");
+            
+            SidebarBlock.PositionConfig config1 = SidebarBlock.PositionConfig.builder()
+                .required(false)
+                .allowed(allowed)
+                .severity(Severity.INFO)
+                .build();
+            
+            SidebarBlock.PositionConfig config2 = SidebarBlock.PositionConfig.builder()
+                .required(false)
+                .allowed(allowed)
+                .severity(Severity.INFO)
+                .build();
+            
+            SidebarBlock.PositionConfig config3 = SidebarBlock.PositionConfig.builder()
+                .required(true)
+                .allowed(allowed)
+                .severity(Severity.INFO)
+                .build();
+            
+            // Then
+            assertEquals(config1, config2);
+            assertEquals(config1.hashCode(), config2.hashCode());
+            assertNotEquals(config1, config3);
+        }
+    }
+    
+    @Nested
+    @DisplayName("equals and hashCode")
+    class EqualsAndHashCodeTest {
+        
+        @Test
+        @DisplayName("should implement equals and hashCode")
+        void shouldImplementEqualsAndHashCode() {
+            // Given
+            SidebarBlock.TitleConfig title = SidebarBlock.TitleConfig.builder()
+                .required(true)
+                .build();
+            
+            SidebarBlock block1 = SidebarBlock.builder()
+                .name("sidebar1")
+                .severity(Severity.ERROR)
+                .title(title)
+                .build();
+            
+            SidebarBlock block2 = SidebarBlock.builder()
+                .name("sidebar1")
+                .severity(Severity.ERROR)
+                .title(title)
+                .build();
+            
+            SidebarBlock block3 = SidebarBlock.builder()
+                .name("sidebar2")
+                .severity(Severity.ERROR)
+                .title(title)
+                .build();
+            
+            // Then
+            assertEquals(block1, block2);
+            assertEquals(block1.hashCode(), block2.hashCode());
+            assertNotEquals(block1, block3);
+            assertNotEquals(block1, null);
+            assertNotEquals(block1, new Object());
+            assertEquals(block1, block1);
+        }
+    }
+}

--- a/src/test/java/com/example/linter/config/loader/SidebarBlockYamlTest.java
+++ b/src/test/java/com/example/linter/config/loader/SidebarBlockYamlTest.java
@@ -1,0 +1,150 @@
+package com.example.linter.config.loader;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.DocumentConfiguration;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.SectionConfig;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.config.blocks.SidebarBlock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for YAML parsing of sidebar block configurations.
+ */
+@DisplayName("SidebarBlock YAML parsing")
+class SidebarBlockYamlTest {
+    
+    @Test
+    @DisplayName("should parse sidebar block with all configurations")
+    void shouldParseSidebarBlockWithAllConfigurations() throws Exception {
+        // Given
+        String yaml = """
+            document:
+              sections:
+                - level: 1
+                  title:
+                    pattern: "Introduction"
+                  allowedBlocks:
+                    - sidebar:
+                        name: "additional-info"
+                        severity: info
+                        occurrence:
+                          min: 0
+                          max: 2
+                          severity: warn
+                        title:
+                          required: false
+                          minLength: 5
+                          maxLength: 50
+                          pattern: "^[A-Z].*$"
+                          severity: info
+                        content:
+                          required: true
+                          minLength: 50
+                          maxLength: 800
+                          lines:
+                            min: 3
+                            max: 30
+                            severity: info
+                        position:
+                          required: false
+                          allowed: ["left", "right", "float"]
+                          severity: info
+            """;
+        
+        ConfigurationLoader loader = new ConfigurationLoader(true); // Skip schema validation
+        
+        // When
+        LinterConfiguration config = loader.loadConfiguration(yaml);
+        
+        // Then
+        assertNotNull(config);
+        assertNotNull(config.document());
+        
+        DocumentConfiguration doc = config.document();
+        assertNotNull(doc.sections());
+        assertEquals(1, doc.sections().size());
+        
+        SectionConfig section = doc.sections().get(0);
+        assertNotNull(section.allowedBlocks());
+        assertEquals(1, section.allowedBlocks().size());
+        
+        Block block = section.allowedBlocks().get(0);
+        assertInstanceOf(SidebarBlock.class, block);
+        
+        SidebarBlock sidebar = (SidebarBlock) block;
+        assertEquals("additional-info", sidebar.getName());
+        assertEquals(Severity.INFO, sidebar.getSeverity());
+        
+        // Validate occurrence
+        assertNotNull(sidebar.getOccurrence());
+        assertEquals(0, sidebar.getOccurrence().min());
+        assertEquals(2, sidebar.getOccurrence().max());
+        assertEquals(Severity.WARN, sidebar.getOccurrence().severity());
+        
+        // Validate title config
+        assertNotNull(sidebar.getTitle());
+        assertFalse(sidebar.getTitle().isRequired());
+        assertEquals(5, sidebar.getTitle().getMinLength());
+        assertEquals(50, sidebar.getTitle().getMaxLength());
+        assertEquals("^[A-Z].*$", sidebar.getTitle().getPattern().pattern());
+        assertEquals(Severity.INFO, sidebar.getTitle().getSeverity());
+        
+        // Validate content config
+        assertNotNull(sidebar.getContent());
+        assertTrue(sidebar.getContent().isRequired());
+        assertEquals(50, sidebar.getContent().getMinLength());
+        assertEquals(800, sidebar.getContent().getMaxLength());
+        
+        // Validate lines config
+        assertNotNull(sidebar.getContent().getLines());
+        assertEquals(3, sidebar.getContent().getLines().getMin());
+        assertEquals(30, sidebar.getContent().getLines().getMax());
+        assertEquals(Severity.INFO, sidebar.getContent().getLines().getSeverity());
+        
+        // Validate position config
+        assertNotNull(sidebar.getPosition());
+        assertFalse(sidebar.getPosition().isRequired());
+        assertEquals(List.of("left", "right", "float"), sidebar.getPosition().getAllowed());
+        assertEquals(Severity.INFO, sidebar.getPosition().getSeverity());
+    }
+    
+    @Test
+    @DisplayName("should parse sidebar block with minimal configuration")
+    void shouldParseSidebarBlockWithMinimalConfiguration() throws Exception {
+        // Given
+        String yaml = """
+            document:
+              sections:
+                - level: 1
+                  title:
+                    pattern: "Section"
+                  allowedBlocks:
+                    - sidebar:
+                        name: "simple-sidebar"
+                        severity: warn
+            """;
+        
+        ConfigurationLoader loader = new ConfigurationLoader(true);
+        
+        // When
+        LinterConfiguration config = loader.loadConfiguration(yaml);
+        
+        // Then
+        Block block = config.document().sections().get(0).allowedBlocks().get(0);
+        assertInstanceOf(SidebarBlock.class, block);
+        
+        SidebarBlock sidebar = (SidebarBlock) block;
+        assertEquals("simple-sidebar", sidebar.getName());
+        assertEquals(Severity.WARN, sidebar.getSeverity());
+        assertNull(sidebar.getTitle());
+        assertNull(sidebar.getContent());
+        assertNull(sidebar.getPosition());
+    }
+}

--- a/src/test/java/com/example/linter/validator/block/SidebarBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/SidebarBlockValidatorTest.java
@@ -1,0 +1,441 @@
+package com.example.linter.validator.block;
+
+import java.util.List;
+
+import org.asciidoctor.ast.Cursor;
+import org.asciidoctor.ast.Section;
+import org.asciidoctor.ast.StructuralNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.SidebarBlock;
+import com.example.linter.validator.ValidationMessage;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("SidebarBlockValidator")
+class SidebarBlockValidatorTest {
+    
+    private SidebarBlockValidator validator;
+    private BlockValidationContext context;
+    
+    @Mock
+    private StructuralNode node;
+    
+    @Mock
+    private Section section;
+    
+    @Mock
+    private Cursor sourceLocation;
+    
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        validator = new SidebarBlockValidator();
+        context = new BlockValidationContext(section, "test.adoc");
+    }
+    
+    @Test
+    @DisplayName("should support SIDEBAR block type")
+    void shouldSupportSidebarBlockType() {
+        assertEquals(BlockType.SIDEBAR, validator.getSupportedType());
+    }
+    
+    @Nested
+    @DisplayName("Title validation")
+    class TitleValidation {
+        
+        @Test
+        @DisplayName("should pass when title is not configured")
+        void shouldPassWhenTitleNotConfigured() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .build();
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertTrue(results.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should fail when required title is missing")
+        void shouldFailWhenRequiredTitleMissing() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .title(SidebarBlock.TitleConfig.builder()
+                    .required(true)
+                    .build())
+                .build();
+            
+            when(node.getTitle()).thenReturn(null);
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertEquals(Severity.ERROR, results.get(0).getSeverity());
+            assertEquals("Sidebar block requires a title", results.get(0).getMessage());
+            assertEquals(10, results.get(0).getLocation().getStartLine());
+        }
+        
+        @Test
+        @DisplayName("should use title severity when specified")
+        void shouldUseTitleSeverityWhenSpecified() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .title(SidebarBlock.TitleConfig.builder()
+                    .required(true)
+                    .severity(Severity.WARN)
+                    .build())
+                .build();
+            
+            when(node.getTitle()).thenReturn(null);
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertEquals(Severity.WARN, results.get(0).getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should validate title length")
+        void shouldValidateTitleLength() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .title(SidebarBlock.TitleConfig.builder()
+                    .minLength(5)
+                    .maxLength(10)
+                    .build())
+                .build();
+            
+            when(node.getTitle()).thenReturn("abc");
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("too short"));
+            assertEquals("3 characters", results.get(0).getActualValue().get());
+        }
+        
+        @Test
+        @DisplayName("should validate title pattern")
+        void shouldValidateTitlePattern() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .title(SidebarBlock.TitleConfig.builder()
+                    .pattern("^[A-Z].*$")
+                    .build())
+                .build();
+            
+            when(node.getTitle()).thenReturn("lowercase");
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("does not match required pattern"));
+        }
+        
+        @Test
+        @DisplayName("should pass valid title")
+        void shouldPassValidTitle() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .title(SidebarBlock.TitleConfig.builder()
+                    .required(true)
+                    .minLength(5)
+                    .maxLength(50)
+                    .pattern("^[A-Z].*$")
+                    .build())
+                .build();
+            
+            when(node.getTitle()).thenReturn("Valid Title");
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertTrue(results.isEmpty());
+        }
+    }
+    
+    @Nested
+    @DisplayName("Content validation")
+    class ContentValidation {
+        
+        @Test
+        @DisplayName("should pass when content is not configured")
+        void shouldPassWhenContentNotConfigured() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .build();
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertTrue(results.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should fail when required content is missing")
+        void shouldFailWhenRequiredContentMissing() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .content(SidebarBlock.ContentConfig.builder()
+                    .required(true)
+                    .build())
+                .build();
+            
+            when(node.getContent()).thenReturn(null);
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertEquals("Sidebar block requires content", results.get(0).getMessage());
+        }
+        
+        @Test
+        @DisplayName("should validate content length")
+        void shouldValidateContentLength() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .content(SidebarBlock.ContentConfig.builder()
+                    .minLength(50)
+                    .maxLength(100)
+                    .build())
+                .build();
+            
+            when(node.getContent()).thenReturn("Short content");
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("too short"));
+        }
+        
+        @Test
+        @DisplayName("should validate line count")
+        void shouldValidateLineCount() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .content(SidebarBlock.ContentConfig.builder()
+                    .lines(SidebarBlock.LinesConfig.builder()
+                        .min(3)
+                        .max(5)
+                        .severity(Severity.WARN)
+                        .build())
+                    .build())
+                .build();
+            
+            when(node.getContent()).thenReturn("Line 1");
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertEquals(Severity.WARN, results.get(0).getSeverity());
+            assertTrue(results.get(0).getMessage().contains("too few lines"));
+        }
+        
+        @Test
+        @DisplayName("should pass valid content")
+        void shouldPassValidContent() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .content(SidebarBlock.ContentConfig.builder()
+                    .required(true)
+                    .minLength(10)
+                    .maxLength(100)
+                    .lines(SidebarBlock.LinesConfig.builder()
+                        .min(1)
+                        .max(5)
+                        .build())
+                    .build())
+                .build();
+            
+            when(node.getContent()).thenReturn("This is valid sidebar content\nWith multiple lines");
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertTrue(results.isEmpty());
+        }
+    }
+    
+    @Nested
+    @DisplayName("Position validation")
+    class PositionValidation {
+        
+        @Test
+        @DisplayName("should pass when position is not configured")
+        void shouldPassWhenPositionNotConfigured() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .build();
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertTrue(results.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should fail when required position is missing")
+        void shouldFailWhenRequiredPositionMissing() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .position(SidebarBlock.PositionConfig.builder()
+                    .required(true)
+                    .build())
+                .build();
+            
+            when(node.getAttribute("position")).thenReturn(null);
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertEquals("Sidebar block requires a position attribute", results.get(0).getMessage());
+        }
+        
+        @Test
+        @DisplayName("should validate allowed positions")
+        void shouldValidateAllowedPositions() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .position(SidebarBlock.PositionConfig.builder()
+                    .allowed(List.of("left", "right", "float"))
+                    .severity(Severity.INFO)
+                    .build())
+                .build();
+            
+            when(node.getAttribute("position")).thenReturn("center");
+            when(node.getSourceLocation()).thenReturn(sourceLocation);
+            when(sourceLocation.getLineNumber()).thenReturn(10);
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertEquals(1, results.size());
+            assertEquals(Severity.INFO, results.get(0).getSeverity());
+            assertTrue(results.get(0).getMessage().contains("Invalid sidebar position"));
+            assertEquals("center", results.get(0).getActualValue().get());
+        }
+        
+        @Test
+        @DisplayName("should pass valid position")
+        void shouldPassValidPosition() {
+            // Given
+            SidebarBlock config = SidebarBlock.builder()
+                .name("test")
+                .severity(Severity.ERROR)
+                .position(SidebarBlock.PositionConfig.builder()
+                    .required(true)
+                    .allowed(List.of("left", "right", "float"))
+                    .build())
+                .build();
+            
+            when(node.getAttribute("position")).thenReturn("left");
+            
+            // When
+            List<ValidationMessage> results = validator.validate(node, config, context);
+            
+            // Then
+            assertTrue(results.isEmpty());
+        }
+    }
+    
+    @Test
+    @DisplayName("should handle null node gracefully")
+    void shouldHandleNullNodeGracefully() {
+        // Given
+        SidebarBlock config = SidebarBlock.builder()
+            .name("test")
+            .severity(Severity.ERROR)
+            .title(SidebarBlock.TitleConfig.builder().required(true).build())
+            .content(SidebarBlock.ContentConfig.builder().required(true).build())
+            .position(SidebarBlock.PositionConfig.builder().required(true).build())
+            .build();
+        
+        when(node.getTitle()).thenReturn(null);
+        when(node.getContent()).thenReturn(null);
+        when(node.getAttribute("position")).thenReturn(null);
+        when(node.getSourceLocation()).thenReturn(null);
+        
+        // When
+        List<ValidationMessage> results = validator.validate(node, config, context);
+        
+        // Then
+        assertEquals(3, results.size());
+        assertTrue(results.stream().allMatch(r -> r.getLocation().getStartLine() == 1));
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented SIDEBAR block type for supplementary information in AsciiDoc documents
- Added complete validation framework with TitleConfig, ContentConfig, LinesConfig, and PositionConfig
- Included comprehensive test coverage and JSON schema definition

## Test plan
- [x] Run all unit tests: `mvn test`
- [x] Verify SIDEBAR block validation works correctly
- [x] Check YAML configuration parsing for SIDEBAR blocks
- [x] Ensure JSON schema validation passes
- [x] Documentation updated with SIDEBAR block examples

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)