### PR TITLE
#45 Add QUOTE block type support

### DIFF
--- a/docs/linter-config-specification.yaml
+++ b/docs/linter-config-specification.yaml
@@ -644,3 +644,31 @@ document:
             lines:
               min: 1
               max: 5                    # Kurze Beschreibungen
+        - quote:
+            name: "important-quote"          # Für Zitate mit Autor und Quelle
+            severity: info                   # PFLICHT: Default-Severity für den gesamten Block
+            occurrence:
+              min: 0
+              max: 3
+              # Kein severity = verwendet Block-Severity (info)
+            # Quote-spezifische Attribute
+            author:
+              required: true                 # Autor ist Pflicht für Zitate
+              minLength: 3
+              maxLength: 100
+              pattern: "^[A-Z][a-zA-Z\\s\\.\\-,]+$"
+              severity: error
+            source:
+              required: false                # Quelle optional
+              minLength: 5
+              maxLength: 200
+              pattern: "^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$"
+              severity: warn
+            content:
+              required: true                 # Zitat-Text ist Pflicht
+              minLength: 20                  # Mindestens 20 Zeichen
+              maxLength: 1000                # Maximal 1000 Zeichen
+              lines:
+                min: 1
+                max: 20
+                severity: info

--- a/src/main/java/com/example/linter/config/BlockType.java
+++ b/src/main/java/com/example/linter/config/BlockType.java
@@ -11,7 +11,8 @@ public enum BlockType {
     VERSE,
     ADMONITION,
     PASS,
-    LITERAL;
+    LITERAL,
+    QUOTE;
     
     @JsonValue
     public String toValue() {
@@ -30,6 +31,7 @@ public enum BlockType {
             case "admonition" -> ADMONITION;
             case "pass" -> PASS;
             case "literal" -> LITERAL;
+            case "quote" -> QUOTE;
             default -> throw new IllegalArgumentException("Unknown block type: " + value);
         };
     }

--- a/src/main/java/com/example/linter/config/blocks/QuoteBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/QuoteBlock.java
@@ -1,0 +1,509 @@
+package com.example.linter.config.blocks;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Configuration for quote blocks.
+ * Based on the YAML schema structure for validating AsciiDoc quote blocks.
+ * 
+ * Syntax: [quote, Autor, Quelle]
+ * ____
+ * Quote content here
+ * ____
+ */
+@JsonDeserialize(builder = QuoteBlock.Builder.class)
+public class QuoteBlock extends AbstractBlock {
+    
+    private final AuthorConfig author;
+    private final SourceConfig source;
+    private final ContentConfig content;
+    
+    private QuoteBlock(Builder builder) {
+        super(builder);
+        this.author = builder.author;
+        this.source = builder.source;
+        this.content = builder.content;
+    }
+    
+    @Override
+    public BlockType getType() {
+        return BlockType.QUOTE;
+    }
+    
+    @JsonProperty("author")
+    public AuthorConfig getAuthor() {
+        return author;
+    }
+    
+    @JsonProperty("source")
+    public SourceConfig getSource() {
+        return source;
+    }
+    
+    @JsonProperty("content")
+    public ContentConfig getContent() {
+        return content;
+    }
+    
+    /**
+     * Configuration for quote author validation.
+     */
+    @JsonDeserialize(builder = AuthorConfig.Builder.class)
+    public static class AuthorConfig {
+        private final boolean required;
+        private final Integer minLength;
+        private final Integer maxLength;
+        private final Pattern pattern;
+        private final Severity severity;
+        
+        private AuthorConfig(Builder builder) {
+            this.required = builder.required;
+            this.minLength = builder.minLength;
+            this.maxLength = builder.maxLength;
+            this.pattern = builder.pattern;
+            this.severity = builder.severity;
+        }
+        
+        @JsonProperty("required")
+        public boolean isRequired() {
+            return required;
+        }
+        
+        @JsonProperty("minLength")
+        public Integer getMinLength() {
+            return minLength;
+        }
+        
+        @JsonProperty("maxLength")
+        public Integer getMaxLength() {
+            return maxLength;
+        }
+        
+        @JsonProperty("pattern")
+        public Pattern getPattern() {
+            return pattern;
+        }
+        
+        @JsonProperty("severity")
+        public Severity getSeverity() {
+            return severity;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AuthorConfig that = (AuthorConfig) o;
+            return required == that.required &&
+                   Objects.equals(minLength, that.minLength) &&
+                   Objects.equals(maxLength, that.maxLength) &&
+                   patternEquals(pattern, that.pattern) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, minLength, maxLength, 
+                               pattern != null ? pattern.pattern() : null, severity);
+        }
+        
+        private boolean patternEquals(Pattern p1, Pattern p2) {
+            if (p1 == p2) return true;
+            if (p1 == null || p2 == null) return false;
+            return p1.pattern().equals(p2.pattern());
+        }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private boolean required = false;
+            private Integer minLength;
+            private Integer maxLength;
+            private Pattern pattern;
+            private Severity severity;
+            
+            @JsonProperty("required")
+            public Builder required(boolean required) {
+                this.required = required;
+                return this;
+            }
+            
+            @JsonProperty("minLength")
+            public Builder minLength(Integer minLength) {
+                this.minLength = minLength;
+                return this;
+            }
+            
+            @JsonProperty("maxLength")
+            public Builder maxLength(Integer maxLength) {
+                this.maxLength = maxLength;
+                return this;
+            }
+            
+            @JsonProperty("pattern")
+            public Builder pattern(String pattern) {
+                this.pattern = pattern != null ? Pattern.compile(pattern) : null;
+                return this;
+            }
+            
+            @JsonProperty("severity")
+            public Builder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public AuthorConfig build() {
+                return new AuthorConfig(this);
+            }
+        }
+    }
+    
+    /**
+     * Configuration for quote source validation.
+     */
+    @JsonDeserialize(builder = SourceConfig.Builder.class)
+    public static class SourceConfig {
+        private final boolean required;
+        private final Integer minLength;
+        private final Integer maxLength;
+        private final Pattern pattern;
+        private final Severity severity;
+        
+        private SourceConfig(Builder builder) {
+            this.required = builder.required;
+            this.minLength = builder.minLength;
+            this.maxLength = builder.maxLength;
+            this.pattern = builder.pattern;
+            this.severity = builder.severity;
+        }
+        
+        @JsonProperty("required")
+        public boolean isRequired() {
+            return required;
+        }
+        
+        @JsonProperty("minLength")
+        public Integer getMinLength() {
+            return minLength;
+        }
+        
+        @JsonProperty("maxLength")
+        public Integer getMaxLength() {
+            return maxLength;
+        }
+        
+        @JsonProperty("pattern")
+        public Pattern getPattern() {
+            return pattern;
+        }
+        
+        @JsonProperty("severity")
+        public Severity getSeverity() {
+            return severity;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SourceConfig that = (SourceConfig) o;
+            return required == that.required &&
+                   Objects.equals(minLength, that.minLength) &&
+                   Objects.equals(maxLength, that.maxLength) &&
+                   patternEquals(pattern, that.pattern) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, minLength, maxLength, 
+                               pattern != null ? pattern.pattern() : null, severity);
+        }
+        
+        private boolean patternEquals(Pattern p1, Pattern p2) {
+            if (p1 == p2) return true;
+            if (p1 == null || p2 == null) return false;
+            return p1.pattern().equals(p2.pattern());
+        }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private boolean required = false;
+            private Integer minLength;
+            private Integer maxLength;
+            private Pattern pattern;
+            private Severity severity;
+            
+            @JsonProperty("required")
+            public Builder required(boolean required) {
+                this.required = required;
+                return this;
+            }
+            
+            @JsonProperty("minLength")
+            public Builder minLength(Integer minLength) {
+                this.minLength = minLength;
+                return this;
+            }
+            
+            @JsonProperty("maxLength")
+            public Builder maxLength(Integer maxLength) {
+                this.maxLength = maxLength;
+                return this;
+            }
+            
+            @JsonProperty("pattern")
+            public Builder pattern(String pattern) {
+                this.pattern = pattern != null ? Pattern.compile(pattern) : null;
+                return this;
+            }
+            
+            @JsonProperty("severity")
+            public Builder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public SourceConfig build() {
+                return new SourceConfig(this);
+            }
+        }
+    }
+    
+    /**
+     * Configuration for quote content validation.
+     */
+    @JsonDeserialize(builder = ContentConfig.Builder.class)
+    public static class ContentConfig {
+        private final boolean required;
+        private final Integer minLength;
+        private final Integer maxLength;
+        private final LinesConfig lines;
+        
+        private ContentConfig(Builder builder) {
+            this.required = builder.required;
+            this.minLength = builder.minLength;
+            this.maxLength = builder.maxLength;
+            this.lines = builder.lines;
+        }
+        
+        @JsonProperty("required")
+        public boolean isRequired() {
+            return required;
+        }
+        
+        @JsonProperty("minLength")
+        public Integer getMinLength() {
+            return minLength;
+        }
+        
+        @JsonProperty("maxLength")
+        public Integer getMaxLength() {
+            return maxLength;
+        }
+        
+        @JsonProperty("lines")
+        public LinesConfig getLines() {
+            return lines;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ContentConfig that = (ContentConfig) o;
+            return required == that.required &&
+                   Objects.equals(minLength, that.minLength) &&
+                   Objects.equals(maxLength, that.maxLength) &&
+                   Objects.equals(lines, that.lines);
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, minLength, maxLength, lines);
+        }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private boolean required = false;
+            private Integer minLength;
+            private Integer maxLength;
+            private LinesConfig lines;
+            
+            @JsonProperty("required")
+            public Builder required(boolean required) {
+                this.required = required;
+                return this;
+            }
+            
+            @JsonProperty("minLength")
+            public Builder minLength(Integer minLength) {
+                this.minLength = minLength;
+                return this;
+            }
+            
+            @JsonProperty("maxLength")
+            public Builder maxLength(Integer maxLength) {
+                this.maxLength = maxLength;
+                return this;
+            }
+            
+            @JsonProperty("lines")
+            public Builder lines(LinesConfig lines) {
+                this.lines = lines;
+                return this;
+            }
+            
+            public ContentConfig build() {
+                return new ContentConfig(this);
+            }
+        }
+    }
+    
+    /**
+     * Configuration for content line count validation.
+     */
+    @JsonDeserialize(builder = LinesConfig.Builder.class)
+    public static class LinesConfig {
+        private final Integer min;
+        private final Integer max;
+        private final Severity severity;
+        
+        private LinesConfig(Builder builder) {
+            this.min = builder.min;
+            this.max = builder.max;
+            this.severity = builder.severity;
+        }
+        
+        @JsonProperty("min")
+        public Integer getMin() {
+            return min;
+        }
+        
+        @JsonProperty("max")
+        public Integer getMax() {
+            return max;
+        }
+        
+        @JsonProperty("severity")
+        public Severity getSeverity() {
+            return severity;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LinesConfig that = (LinesConfig) o;
+            return Objects.equals(min, that.min) &&
+                   Objects.equals(max, that.max) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(min, max, severity);
+        }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private Integer min;
+            private Integer max;
+            private Severity severity;
+            
+            @JsonProperty("min")
+            public Builder min(Integer min) {
+                this.min = min;
+                return this;
+            }
+            
+            @JsonProperty("max")
+            public Builder max(Integer max) {
+                this.max = max;
+                return this;
+            }
+            
+            @JsonProperty("severity")
+            public Builder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public LinesConfig build() {
+                return new LinesConfig(this);
+            }
+        }
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!super.equals(o)) return false;
+        QuoteBlock that = (QuoteBlock) o;
+        return Objects.equals(author, that.author) &&
+               Objects.equals(source, that.source) &&
+               Objects.equals(content, that.content);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), author, source, content);
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends AbstractBlock.AbstractBuilder<Builder> {
+        private AuthorConfig author;
+        private SourceConfig source;
+        private ContentConfig content;
+        
+        @JsonProperty("author")
+        public Builder author(AuthorConfig author) {
+            this.author = author;
+            return this;
+        }
+        
+        @JsonProperty("source")
+        public Builder source(SourceConfig source) {
+            this.source = source;
+            return this;
+        }
+        
+        @JsonProperty("content")
+        public Builder content(ContentConfig content) {
+            this.content = content;
+            return this;
+        }
+        
+        @Override
+        public QuoteBlock build() {
+            Objects.requireNonNull(severity, "severity is required");
+            return new QuoteBlock(this);
+        }
+    }
+}

--- a/src/main/java/com/example/linter/config/loader/BlockListDeserializer.java
+++ b/src/main/java/com/example/linter/config/loader/BlockListDeserializer.java
@@ -12,6 +12,7 @@ import com.example.linter.config.blocks.ListingBlock;
 import com.example.linter.config.blocks.LiteralBlock;
 import com.example.linter.config.blocks.ParagraphBlock;
 import com.example.linter.config.blocks.PassBlock;
+import com.example.linter.config.blocks.QuoteBlock;
 import com.example.linter.config.blocks.TableBlock;
 import com.example.linter.config.blocks.VerseBlock;
 import com.fasterxml.jackson.core.JsonParser;
@@ -74,6 +75,7 @@ public class BlockListDeserializer extends JsonDeserializer<List<Block>> {
                 case ADMONITION -> mapper.treeToValue(blockData, AdmonitionBlock.class);
                 case PASS -> mapper.treeToValue(blockData, PassBlock.class);
                 case LITERAL -> mapper.treeToValue(blockData, LiteralBlock.class);
+                case QUOTE -> mapper.treeToValue(blockData, QuoteBlock.class);
             };
             
             blocks.add(block);

--- a/src/main/java/com/example/linter/validator/block/BlockTypeDetector.java
+++ b/src/main/java/com/example/linter/validator/block/BlockTypeDetector.java
@@ -70,14 +70,30 @@ public final class BlockTypeDetector {
     }
     
     /**
-     * Determines if a quote/verse block is actually a verse block.
+     * Determines if a quote/verse block is actually a verse block or quote block.
      */
     private BlockType detectVerseOrQuote(StructuralNode node) {
-        // Verse blocks typically have attribution or cite attributes
+        // Check if it has verse style explicitly
+        if ("verse".equals(node.getStyle())) {
+            return BlockType.VERSE;
+        }
+        
+        // If context is "verse", it's definitely a verse block
+        if ("verse".equals(node.getContext())) {
+            return BlockType.VERSE;
+        }
+        
+        // If context is "quote", it's a quote block
+        if ("quote".equals(node.getContext())) {
+            return BlockType.QUOTE;
+        }
+        
+        // Default: if it has attribution or citetitle, treat as quote
         if (node.getAttribute("attribution") != null || 
             node.getAttribute("citetitle") != null ||
-            "verse".equals(node.getStyle())) {
-            return BlockType.VERSE;
+            node.getAttribute("author") != null ||
+            node.getAttribute("source") != null) {
+            return BlockType.QUOTE;
         }
         
         // Could be a quote block containing other content

--- a/src/main/java/com/example/linter/validator/block/BlockValidatorFactory.java
+++ b/src/main/java/com/example/linter/validator/block/BlockValidatorFactory.java
@@ -52,6 +52,7 @@ public final class BlockValidatorFactory {
         registerValidator(map, new AdmonitionBlockValidator());
         registerValidator(map, new PassBlockValidator());
         registerValidator(map, new LiteralBlockValidator());
+        registerValidator(map, new QuoteBlockValidator());
         
         return map;
     }

--- a/src/main/java/com/example/linter/validator/block/QuoteBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/QuoteBlockValidator.java
@@ -1,0 +1,293 @@
+package com.example.linter.validator.block;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.config.blocks.QuoteBlock;
+import com.example.linter.validator.ValidationMessage;
+import org.asciidoctor.ast.StructuralNode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Validator for quote blocks.
+ * Based on the YAML schema structure for validating AsciiDoc quote blocks.
+ */
+public class QuoteBlockValidator implements BlockTypeValidator {
+    
+    @Override
+    public BlockType getSupportedType() {
+        return BlockType.QUOTE;
+    }
+    
+    @Override
+    public List<ValidationMessage> validate(StructuralNode node, Block blockConfig, BlockValidationContext context) {
+        List<ValidationMessage> results = new ArrayList<>();
+        
+        if (!(blockConfig instanceof QuoteBlock quoteBlock)) {
+            return results;
+        }
+        
+        // Validate author
+        if (quoteBlock.getAuthor() != null) {
+            validateAuthor(node, quoteBlock.getAuthor(), quoteBlock.getSeverity(), results, context);
+        }
+        
+        // Validate source
+        if (quoteBlock.getSource() != null) {
+            validateSource(node, quoteBlock.getSource(), quoteBlock.getSeverity(), results, context);
+        }
+        
+        // Validate content
+        if (quoteBlock.getContent() != null) {
+            validateContent(node, quoteBlock.getContent(), quoteBlock.getSeverity(), results, context);
+        }
+        
+        return results;
+    }
+    
+    private void validateAuthor(StructuralNode node, QuoteBlock.AuthorConfig config, 
+                               Severity blockSeverity, List<ValidationMessage> results,
+                               BlockValidationContext context) {
+        String author = extractAuthor(node);
+        Severity severity = config.getSeverity() != null ? config.getSeverity() : blockSeverity;
+        
+        if (config.isRequired() && (author == null || author.trim().isEmpty())) {
+            results.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("quote.author.required")
+                .message("Quote block requires an author")
+                .location(context.createLocation(node))
+                .build());
+            return;
+        }
+        
+        if (author != null && !author.trim().isEmpty()) {
+            // Validate minLength
+            if (config.getMinLength() != null && author.length() < config.getMinLength()) {
+                results.add(ValidationMessage.builder()
+                    .severity(severity)
+                    .ruleId("quote.author.minLength")
+                    .message(String.format("Quote author is too short (minimum %d characters, found %d)",
+                                  config.getMinLength(), author.length()))
+                    .location(context.createLocation(node))
+                    .build());
+            }
+            
+            // Validate maxLength
+            if (config.getMaxLength() != null && author.length() > config.getMaxLength()) {
+                results.add(ValidationMessage.builder()
+                    .severity(severity)
+                    .ruleId("quote.author.maxLength")
+                    .message(String.format("Quote author is too long (maximum %d characters, found %d)",
+                                  config.getMaxLength(), author.length()))
+                    .location(context.createLocation(node))
+                    .build());
+            }
+            
+            // Validate pattern
+            if (config.getPattern() != null && !config.getPattern().matcher(author).matches()) {
+                results.add(ValidationMessage.builder()
+                    .severity(severity)
+                    .ruleId("quote.author.pattern")
+                    .message(String.format("Quote author does not match required pattern: %s (actual: %s)",
+                                  config.getPattern().pattern(), author))
+                    .location(context.createLocation(node))
+                    .build());
+            }
+        }
+    }
+    
+    private void validateSource(StructuralNode node, QuoteBlock.SourceConfig config,
+                               Severity blockSeverity, List<ValidationMessage> results,
+                               BlockValidationContext context) {
+        String source = extractSource(node);
+        Severity severity = config.getSeverity() != null ? config.getSeverity() : blockSeverity;
+        
+        if (config.isRequired() && (source == null || source.trim().isEmpty())) {
+            results.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("quote.source.required")
+                .message("Quote block requires a source")
+                .location(context.createLocation(node))
+                .build());
+            return;
+        }
+        
+        if (source != null && !source.trim().isEmpty()) {
+            // Validate minLength
+            if (config.getMinLength() != null && source.length() < config.getMinLength()) {
+                results.add(ValidationMessage.builder()
+                    .severity(severity)
+                    .ruleId("quote.source.minLength")
+                    .message(String.format("Quote source is too short (minimum %d characters, found %d)",
+                                  config.getMinLength(), source.length()))
+                    .location(context.createLocation(node))
+                    .build());
+            }
+            
+            // Validate maxLength
+            if (config.getMaxLength() != null && source.length() > config.getMaxLength()) {
+                results.add(ValidationMessage.builder()
+                    .severity(severity)
+                    .ruleId("quote.source.maxLength")
+                    .message(String.format("Quote source is too long (maximum %d characters, found %d)",
+                                  config.getMaxLength(), source.length()))
+                    .location(context.createLocation(node))
+                    .build());
+            }
+            
+            // Validate pattern
+            if (config.getPattern() != null && !config.getPattern().matcher(source).matches()) {
+                results.add(ValidationMessage.builder()
+                    .severity(severity)
+                    .ruleId("quote.source.pattern")
+                    .message(String.format("Quote source does not match required pattern: %s (actual: %s)",
+                                  config.getPattern().pattern(), source))
+                    .location(context.createLocation(node))
+                    .build());
+            }
+        }
+    }
+    
+    private void validateContent(StructuralNode node, QuoteBlock.ContentConfig config,
+                                Severity blockSeverity, List<ValidationMessage> results,
+                                BlockValidationContext context) {
+        String content = extractContent(node);
+        
+        if (config.isRequired() && (content == null || content.trim().isEmpty())) {
+            results.add(ValidationMessage.builder()
+                .severity(blockSeverity)
+                .ruleId("quote.content.required")
+                .message("Quote block requires content")
+                .location(context.createLocation(node))
+                .build());
+            return;
+        }
+        
+        if (content != null && !content.trim().isEmpty()) {
+            // Validate minLength
+            if (config.getMinLength() != null && content.length() < config.getMinLength()) {
+                results.add(ValidationMessage.builder()
+                    .severity(blockSeverity)
+                    .ruleId("quote.content.minLength")
+                    .message(String.format("Quote content is too short (minimum %d characters, found %d)",
+                                  config.getMinLength(), content.length()))
+                    .location(context.createLocation(node))
+                    .build());
+            }
+            
+            // Validate maxLength
+            if (config.getMaxLength() != null && content.length() > config.getMaxLength()) {
+                results.add(ValidationMessage.builder()
+                    .severity(blockSeverity)
+                    .ruleId("quote.content.maxLength")
+                    .message(String.format("Quote content is too long (maximum %d characters, found %d)",
+                                  config.getMaxLength(), content.length()))
+                    .location(context.createLocation(node))
+                    .build());
+            }
+            
+            // Validate lines
+            if (config.getLines() != null) {
+                validateLines(node, content, config.getLines(), blockSeverity, results, context);
+            }
+        }
+    }
+    
+    private void validateLines(StructuralNode node, String content, QuoteBlock.LinesConfig config,
+                              Severity blockSeverity, List<ValidationMessage> results,
+                              BlockValidationContext context) {
+        String[] lines = content.split("\n");
+        int lineCount = lines.length;
+        Severity severity = config.getSeverity() != null ? config.getSeverity() : blockSeverity;
+        
+        if (config.getMin() != null && lineCount < config.getMin()) {
+            results.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("quote.content.lines.min")
+                .message(String.format("Quote content has too few lines (minimum %d, found %d)",
+                              config.getMin(), lineCount))
+                .location(context.createLocation(node))
+                .build());
+        }
+        
+        if (config.getMax() != null && lineCount > config.getMax()) {
+            results.add(ValidationMessage.builder()
+                .severity(severity)
+                .ruleId("quote.content.lines.max")
+                .message(String.format("Quote content has too many lines (maximum %d, found %d)",
+                              config.getMax(), lineCount))
+                .location(context.createLocation(node))
+                .build());
+        }
+    }
+    
+    private String extractAuthor(StructuralNode node) {
+        // Check for author attribute (standard way)
+        Object author = node.getAttribute("author");
+        if (author != null) {
+            return author.toString();
+        }
+        
+        // Check for attribution (alternative way)
+        Object attribution = node.getAttribute("attribution");
+        if (attribution != null) {
+            return attribution.toString();
+        }
+        
+        // Check for positional attribute [quote, Author, Source]
+        Object attr1 = node.getAttribute("1");
+        if (attr1 != null) {
+            return attr1.toString();
+        }
+        
+        return null;
+    }
+    
+    private String extractSource(StructuralNode node) {
+        // Check for citetitle attribute (standard way for source)
+        Object citetitle = node.getAttribute("citetitle");
+        if (citetitle != null) {
+            return citetitle.toString();
+        }
+        
+        // Check for source attribute (alternative way)
+        Object source = node.getAttribute("source");
+        if (source != null) {
+            return source.toString();
+        }
+        
+        // Check for positional attribute [quote, Author, Source]
+        Object attr2 = node.getAttribute("2");
+        if (attr2 != null) {
+            return attr2.toString();
+        }
+        
+        return null;
+    }
+    
+    private String extractContent(StructuralNode node) {
+        // Try to get content as string
+        if (node.getContent() instanceof String) {
+            return (String) node.getContent();
+        }
+        
+        // Try to get source (raw content)
+        if (node instanceof org.asciidoctor.ast.Block) {
+            List<String> lines = ((org.asciidoctor.ast.Block) node).getLines();
+            if (lines != null && !lines.isEmpty()) {
+                return String.join("\n", lines);
+            }
+        }
+        
+        // Fallback to content object toString
+        if (node.getContent() != null) {
+            return node.getContent().toString();
+        }
+        
+        return null;
+    }
+}

--- a/src/main/resources/schemas/blocks/quote-block-schema.yaml
+++ b/src/main/resources/schemas/blocks/quote-block-schema.yaml
@@ -1,0 +1,97 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+$id: "quote-block-schema.yaml"
+title: "Quote Block Configuration"
+description: "Schema for quote block configuration in AsciiDoc linter"
+type: object
+properties:
+  name:
+    type: string
+    description: "Optional name for the quote block for better error messages"
+  severity:
+    $ref: "../common/severity-schema.yaml"
+    description: "Default severity for all quote block violations"
+  occurrence:
+    $ref: "../common/occurrence-schema.yaml"
+    description: "Constraints on quote block occurrence"
+  author:
+    type: object
+    description: "Author validation rules"
+    properties:
+      required:
+        type: boolean
+        default: false
+        description: "Whether author is required"
+      minLength:
+        type: integer
+        minimum: 1
+        description: "Minimum length for author"
+      maxLength:
+        type: integer
+        minimum: 1
+        description: "Maximum length for author"
+      pattern:
+        type: string
+        description: "Regular expression pattern for author"
+      severity:
+        $ref: "../common/severity-schema.yaml"
+        description: "Severity for author violations (overrides block severity)"
+    additionalProperties: false
+  source:
+    type: object
+    description: "Source/citation validation rules"
+    properties:
+      required:
+        type: boolean
+        default: false
+        description: "Whether source is required"
+      minLength:
+        type: integer
+        minimum: 1
+        description: "Minimum length for source"
+      maxLength:
+        type: integer
+        minimum: 1
+        description: "Maximum length for source"
+      pattern:
+        type: string
+        description: "Regular expression pattern for source"
+      severity:
+        $ref: "../common/severity-schema.yaml"
+        description: "Severity for source violations (overrides block severity)"
+    additionalProperties: false
+  content:
+    type: object
+    description: "Content validation rules"
+    properties:
+      required:
+        type: boolean
+        default: false
+        description: "Whether content is required"
+      minLength:
+        type: integer
+        minimum: 1
+        description: "Minimum length for content"
+      maxLength:
+        type: integer
+        minimum: 1
+        description: "Maximum length for content"
+      lines:
+        type: object
+        description: "Line count validation"
+        properties:
+          min:
+            type: integer
+            minimum: 1
+            description: "Minimum number of lines"
+          max:
+            type: integer
+            minimum: 1
+            description: "Maximum number of lines"
+          severity:
+            $ref: "../common/severity-schema.yaml"
+            description: "Severity for line count violations (overrides block severity)"
+        additionalProperties: false
+    additionalProperties: false
+required:
+  - severity
+additionalProperties: false

--- a/src/test/java/com/example/linter/config/blocks/QuoteBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/QuoteBlockTest.java
@@ -1,0 +1,363 @@
+package com.example.linter.config.blocks;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.OccurrenceConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("QuoteBlock Configuration Tests")
+class QuoteBlockTest {
+    
+    @Test
+    @DisplayName("should return QUOTE as block type")
+    void shouldReturnCorrectBlockType() {
+        QuoteBlock block = QuoteBlock.builder()
+                .severity(Severity.INFO)
+                .build();
+        
+        assertEquals(BlockType.QUOTE, block.getType());
+    }
+    
+    @Nested
+    @DisplayName("Builder Tests")
+    class BuilderTests {
+        
+        @Test
+        @DisplayName("should build with minimal configuration")
+        void shouldBuildWithMinimalConfig() {
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .build();
+            
+            assertNotNull(block);
+            assertEquals(Severity.WARN, block.getSeverity());
+            assertNull(block.getAuthor());
+            assertNull(block.getSource());
+            assertNull(block.getContent());
+        }
+        
+        @Test
+        @DisplayName("should build with complete configuration")
+        void shouldBuildWithCompleteConfig() {
+            QuoteBlock.AuthorConfig author = QuoteBlock.AuthorConfig.builder()
+                    .required(true)
+                    .minLength(3)
+                    .maxLength(100)
+                    .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$")
+                    .severity(Severity.ERROR)
+                    .build();
+            
+            QuoteBlock.SourceConfig source = QuoteBlock.SourceConfig.builder()
+                    .required(false)
+                    .minLength(5)
+                    .maxLength(200)
+                    .pattern("^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$")
+                    .severity(Severity.WARN)
+                    .build();
+            
+            QuoteBlock.ContentConfig content = QuoteBlock.ContentConfig.builder()
+                    .required(true)
+                    .minLength(20)
+                    .maxLength(1000)
+                    .lines(QuoteBlock.LinesConfig.builder()
+                            .min(1)
+                            .max(20)
+                            .severity(Severity.INFO)
+                            .build())
+                    .build();
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .name("important-quote")
+                    .severity(Severity.INFO)
+                    .occurrence(OccurrenceConfig.builder()
+                            .min(0)
+                            .max(3)
+                            .build())
+                    .author(author)
+                    .source(source)
+                    .content(content)
+                    .build();
+            
+            assertNotNull(block);
+            assertEquals("important-quote", block.getName());
+            assertEquals(Severity.INFO, block.getSeverity());
+            assertNotNull(block.getOccurrence());
+            assertEquals(0, block.getOccurrence().min());
+            assertEquals(3, block.getOccurrence().max());
+            assertNotNull(block.getAuthor());
+            assertTrue(block.getAuthor().isRequired());
+            assertNotNull(block.getSource());
+            assertFalse(block.getSource().isRequired());
+            assertNotNull(block.getContent());
+            assertTrue(block.getContent().isRequired());
+        }
+        
+        @Test
+        @DisplayName("should throw exception when severity is null")
+        void shouldThrowWhenSeverityNull() {
+            assertThrows(NullPointerException.class, () -> 
+                    QuoteBlock.builder().build(),
+                    "severity is required"
+            );
+        }
+    }
+    
+    @Nested
+    @DisplayName("AuthorConfig Tests")
+    class AuthorConfigTests {
+        
+        @Test
+        @DisplayName("should build with default values")
+        void shouldBuildWithDefaults() {
+            QuoteBlock.AuthorConfig config = QuoteBlock.AuthorConfig.builder().build();
+            
+            assertFalse(config.isRequired());
+            assertNull(config.getMinLength());
+            assertNull(config.getMaxLength());
+            assertNull(config.getPattern());
+            assertNull(config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should build with all values")
+        void shouldBuildWithAllValues() {
+            QuoteBlock.AuthorConfig config = QuoteBlock.AuthorConfig.builder()
+                    .required(true)
+                    .minLength(5)
+                    .maxLength(50)
+                    .pattern("^[A-Z].*")
+                    .severity(Severity.ERROR)
+                    .build();
+            
+            assertTrue(config.isRequired());
+            assertEquals(5, config.getMinLength());
+            assertEquals(50, config.getMaxLength());
+            assertNotNull(config.getPattern());
+            assertEquals("^[A-Z].*", config.getPattern().pattern());
+            assertEquals(Severity.ERROR, config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should implement equals and hashCode correctly")
+        void shouldImplementEqualsAndHashCode() {
+            QuoteBlock.AuthorConfig config1 = QuoteBlock.AuthorConfig.builder()
+                    .required(true)
+                    .minLength(5)
+                    .pattern("^[A-Z].*")
+                    .build();
+            
+            QuoteBlock.AuthorConfig config2 = QuoteBlock.AuthorConfig.builder()
+                    .required(true)
+                    .minLength(5)
+                    .pattern("^[A-Z].*")
+                    .build();
+            
+            QuoteBlock.AuthorConfig config3 = QuoteBlock.AuthorConfig.builder()
+                    .required(false)
+                    .minLength(5)
+                    .pattern("^[A-Z].*")
+                    .build();
+            
+            assertEquals(config1, config2);
+            assertEquals(config1.hashCode(), config2.hashCode());
+            assertNotEquals(config1, config3);
+        }
+    }
+    
+    @Nested
+    @DisplayName("SourceConfig Tests")
+    class SourceConfigTests {
+        
+        @Test
+        @DisplayName("should build with default values")
+        void shouldBuildWithDefaults() {
+            QuoteBlock.SourceConfig config = QuoteBlock.SourceConfig.builder().build();
+            
+            assertFalse(config.isRequired());
+            assertNull(config.getMinLength());
+            assertNull(config.getMaxLength());
+            assertNull(config.getPattern());
+            assertNull(config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should build with all values")
+        void shouldBuildWithAllValues() {
+            QuoteBlock.SourceConfig config = QuoteBlock.SourceConfig.builder()
+                    .required(true)
+                    .minLength(10)
+                    .maxLength(100)
+                    .pattern("^[A-Za-z0-9\\\\s]+$")
+                    .severity(Severity.WARN)
+                    .build();
+            
+            assertTrue(config.isRequired());
+            assertEquals(10, config.getMinLength());
+            assertEquals(100, config.getMaxLength());
+            assertNotNull(config.getPattern());
+            assertEquals("^[A-Za-z0-9\\\\s]+$", config.getPattern().pattern());
+            assertEquals(Severity.WARN, config.getSeverity());
+        }
+    }
+    
+    @Nested
+    @DisplayName("ContentConfig Tests")
+    class ContentConfigTests {
+        
+        @Test
+        @DisplayName("should build with default values")
+        void shouldBuildWithDefaults() {
+            QuoteBlock.ContentConfig config = QuoteBlock.ContentConfig.builder().build();
+            
+            assertFalse(config.isRequired());
+            assertNull(config.getMinLength());
+            assertNull(config.getMaxLength());
+            assertNull(config.getLines());
+        }
+        
+        @Test
+        @DisplayName("should build with all values")
+        void shouldBuildWithAllValues() {
+            QuoteBlock.LinesConfig lines = QuoteBlock.LinesConfig.builder()
+                    .min(2)
+                    .max(10)
+                    .severity(Severity.INFO)
+                    .build();
+            
+            QuoteBlock.ContentConfig config = QuoteBlock.ContentConfig.builder()
+                    .required(true)
+                    .minLength(50)
+                    .maxLength(500)
+                    .lines(lines)
+                    .build();
+            
+            assertTrue(config.isRequired());
+            assertEquals(50, config.getMinLength());
+            assertEquals(500, config.getMaxLength());
+            assertNotNull(config.getLines());
+            assertEquals(2, config.getLines().getMin());
+            assertEquals(10, config.getLines().getMax());
+        }
+    }
+    
+    @Nested
+    @DisplayName("LinesConfig Tests")
+    class LinesConfigTests {
+        
+        @Test
+        @DisplayName("should build with default values")
+        void shouldBuildWithDefaults() {
+            QuoteBlock.LinesConfig config = QuoteBlock.LinesConfig.builder().build();
+            
+            assertNull(config.getMin());
+            assertNull(config.getMax());
+            assertNull(config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should build with all values")
+        void shouldBuildWithAllValues() {
+            QuoteBlock.LinesConfig config = QuoteBlock.LinesConfig.builder()
+                    .min(1)
+                    .max(20)
+                    .severity(Severity.WARN)
+                    .build();
+            
+            assertEquals(1, config.getMin());
+            assertEquals(20, config.getMax());
+            assertEquals(Severity.WARN, config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should implement equals and hashCode correctly")
+        void shouldImplementEqualsAndHashCode() {
+            QuoteBlock.LinesConfig config1 = QuoteBlock.LinesConfig.builder()
+                    .min(5)
+                    .max(10)
+                    .severity(Severity.INFO)
+                    .build();
+            
+            QuoteBlock.LinesConfig config2 = QuoteBlock.LinesConfig.builder()
+                    .min(5)
+                    .max(10)
+                    .severity(Severity.INFO)
+                    .build();
+            
+            QuoteBlock.LinesConfig config3 = QuoteBlock.LinesConfig.builder()
+                    .min(5)
+                    .max(15)
+                    .severity(Severity.INFO)
+                    .build();
+            
+            assertEquals(config1, config2);
+            assertEquals(config1.hashCode(), config2.hashCode());
+            assertNotEquals(config1, config3);
+        }
+    }
+    
+    @Nested
+    @DisplayName("Equals and HashCode Tests")
+    class EqualsHashCodeTests {
+        
+        @Test
+        @DisplayName("should implement equals correctly")
+        void shouldImplementEquals() {
+            QuoteBlock block1 = QuoteBlock.builder()
+                    .name("quote1")
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .required(true)
+                            .build())
+                    .build();
+            
+            QuoteBlock block2 = QuoteBlock.builder()
+                    .name("quote1")
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .required(true)
+                            .build())
+                    .build();
+            
+            QuoteBlock block3 = QuoteBlock.builder()
+                    .name("quote2")
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .required(true)
+                            .build())
+                    .build();
+            
+            assertEquals(block1, block2);
+            assertNotEquals(block1, block3);
+            assertNotEquals(block1, null);
+            assertNotEquals(block1, new Object());
+        }
+        
+        @Test
+        @DisplayName("should implement hashCode consistently")
+        void shouldImplementHashCode() {
+            QuoteBlock block1 = QuoteBlock.builder()
+                    .severity(Severity.ERROR)
+                    .source(QuoteBlock.SourceConfig.builder()
+                            .required(false)
+                            .maxLength(100)
+                            .build())
+                    .build();
+            
+            QuoteBlock block2 = QuoteBlock.builder()
+                    .severity(Severity.ERROR)
+                    .source(QuoteBlock.SourceConfig.builder()
+                            .required(false)
+                            .maxLength(100)
+                            .build())
+                    .build();
+            
+            assertEquals(block1.hashCode(), block2.hashCode());
+        }
+    }
+}

--- a/src/test/java/com/example/linter/config/loader/QuoteBlockYamlTest.java
+++ b/src/test/java/com/example/linter/config/loader/QuoteBlockYamlTest.java
@@ -1,0 +1,152 @@
+package com.example.linter.config.loader;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.DocumentConfiguration;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.QuoteBlock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("QuoteBlock YAML Loading Tests")
+class QuoteBlockYamlTest {
+    
+    private ConfigurationLoader loader;
+    
+    @BeforeEach
+    void setUp() {
+        loader = new ConfigurationLoader(true); // Skip schema validation for tests
+    }
+    
+    @Test
+    @DisplayName("should load quote block from YAML with all configurations")
+    void shouldLoadQuoteBlockFromYaml() throws Exception {
+        String yaml = """
+                document:
+                  sections:
+                    - name: "test-section"
+                      level: 1
+                      min: 1
+                      max: 1
+                      allowedBlocks:
+                        - quote:
+                            name: "important-quote"
+                            severity: info
+                            occurrence:
+                              min: 0
+                              max: 3
+                              severity: warn
+                            author:
+                              required: true
+                              minLength: 3
+                              maxLength: 100
+                              pattern: "^[A-Z][a-zA-Z\\\\s\\\\.\\\\-,]+$"
+                              severity: error
+                            source:
+                              required: false
+                              minLength: 5
+                              maxLength: 200
+                              pattern: "^[A-Za-z0-9\\\\s,\\\\.\\\\-\\\\(\\\\)]+$"
+                              severity: warn
+                            content:
+                              required: true
+                              minLength: 20
+                              maxLength: 1000
+                              lines:
+                                min: 1
+                                max: 20
+                                severity: info
+                """;
+        
+        InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+        LinterConfiguration config = loader.loadConfiguration(stream);
+        
+        assertNotNull(config);
+        assertNotNull(config.document());
+        assertNotNull(config.document().sections());
+        assertEquals(1, config.document().sections().size());
+        
+        var section = config.document().sections().get(0);
+        assertNotNull(section.allowedBlocks());
+        assertEquals(1, section.allowedBlocks().size());
+        
+        var block = section.allowedBlocks().get(0);
+        assertInstanceOf(QuoteBlock.class, block);
+        
+        QuoteBlock quoteBlock = (QuoteBlock) block;
+        assertEquals("important-quote", quoteBlock.getName());
+        assertEquals(Severity.INFO, quoteBlock.getSeverity());
+        assertEquals(BlockType.QUOTE, quoteBlock.getType());
+        
+        // Verify occurrence
+        assertNotNull(quoteBlock.getOccurrence());
+        assertEquals(0, quoteBlock.getOccurrence().min());
+        assertEquals(3, quoteBlock.getOccurrence().max());
+        assertEquals(Severity.WARN, quoteBlock.getOccurrence().severity());
+        
+        // Verify author config
+        assertNotNull(quoteBlock.getAuthor());
+        assertTrue(quoteBlock.getAuthor().isRequired());
+        assertEquals(3, quoteBlock.getAuthor().getMinLength());
+        assertEquals(100, quoteBlock.getAuthor().getMaxLength());
+        assertEquals("^[A-Z][a-zA-Z\\s\\.\\-,]+$", quoteBlock.getAuthor().getPattern().pattern());
+        assertEquals(Severity.ERROR, quoteBlock.getAuthor().getSeverity());
+        
+        // Verify source config
+        assertNotNull(quoteBlock.getSource());
+        assertFalse(quoteBlock.getSource().isRequired());
+        assertEquals(5, quoteBlock.getSource().getMinLength());
+        assertEquals(200, quoteBlock.getSource().getMaxLength());
+        assertEquals("^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$", quoteBlock.getSource().getPattern().pattern());
+        assertEquals(Severity.WARN, quoteBlock.getSource().getSeverity());
+        
+        // Verify content config
+        assertNotNull(quoteBlock.getContent());
+        assertTrue(quoteBlock.getContent().isRequired());
+        assertEquals(20, quoteBlock.getContent().getMinLength());
+        assertEquals(1000, quoteBlock.getContent().getMaxLength());
+        
+        // Verify lines config
+        assertNotNull(quoteBlock.getContent().getLines());
+        assertEquals(1, quoteBlock.getContent().getLines().getMin());
+        assertEquals(20, quoteBlock.getContent().getLines().getMax());
+        assertEquals(Severity.INFO, quoteBlock.getContent().getLines().getSeverity());
+    }
+    
+    @Test
+    @DisplayName("should load quote block with minimal configuration")
+    void shouldLoadQuoteBlockWithMinimalConfig() throws Exception {
+        String yaml = """
+                document:
+                  sections:
+                    - name: "test-section"
+                      level: 1
+                      min: 1
+                      max: 1
+                      allowedBlocks:
+                        - quote:
+                            severity: info
+                """;
+        
+        InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+        LinterConfiguration config = loader.loadConfiguration(stream);
+        
+        var block = config.document().sections().get(0).allowedBlocks().get(0);
+        assertInstanceOf(QuoteBlock.class, block);
+        
+        QuoteBlock quoteBlock = (QuoteBlock) block;
+        assertEquals(Severity.INFO, quoteBlock.getSeverity());
+        assertNull(quoteBlock.getName());
+        assertNull(quoteBlock.getOccurrence());
+        assertNull(quoteBlock.getAuthor());
+        assertNull(quoteBlock.getSource());
+        assertNull(quoteBlock.getContent());
+    }
+}

--- a/src/test/java/com/example/linter/validator/block/BlockTypeDetectorTest.java
+++ b/src/test/java/com/example/linter/validator/block/BlockTypeDetectorTest.java
@@ -137,8 +137,8 @@ class BlockTypeDetectorTest {
         }
         
         @Test
-        @DisplayName("should detect verse block from quote with attribution")
-        void shouldDetectVerseBlockFromQuoteWithAttribution() {
+        @DisplayName("should detect quote block from quote with attribution")
+        void shouldDetectQuoteBlockFromQuoteWithAttribution() {
             // Given
             when(mockNode.getContext()).thenReturn("quote");
             when(mockNode.getAttribute("attribution")).thenReturn("Some Author");
@@ -147,7 +147,7 @@ class BlockTypeDetectorTest {
             BlockType result = detector.detectType(mockNode);
             
             // Then
-            assertEquals(BlockType.VERSE, result);
+            assertEquals(BlockType.QUOTE, result);
         }
         
         @Test

--- a/src/test/java/com/example/linter/validator/block/QuoteBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/QuoteBlockValidatorTest.java
@@ -1,0 +1,470 @@
+package com.example.linter.validator.block;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.config.blocks.QuoteBlock;
+import com.example.linter.validator.ValidationMessage;
+import com.example.linter.validator.SourceLocation;
+import org.asciidoctor.ast.StructuralNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@DisplayName("QuoteBlockValidator Tests")
+class QuoteBlockValidatorTest {
+    
+    private QuoteBlockValidator validator;
+    private StructuralNode mockNode;
+    private BlockValidationContext mockContext;
+    
+    @BeforeEach
+    void setUp() {
+        validator = new QuoteBlockValidator();
+        mockNode = mock(StructuralNode.class);
+        mockContext = mock(BlockValidationContext.class);
+        
+        // Mock the location creation
+        SourceLocation mockLocation = mock(SourceLocation.class);
+        when(mockContext.createLocation(any(StructuralNode.class))).thenReturn(mockLocation);
+        when(mockNode.getSourceLocation()).thenReturn(null);
+    }
+    
+    @Test
+    @DisplayName("should return QUOTE block type")
+    void shouldReturnCorrectBlockType() {
+        assertEquals(BlockType.QUOTE, validator.getSupportedType());
+    }
+    
+    @Test
+    @DisplayName("should return empty list for non-quote block config")
+    void shouldReturnEmptyListForNonQuoteBlock() {
+        Block nonQuoteBlock = mock(Block.class);
+        List<ValidationMessage> results = validator.validate(mockNode, nonQuoteBlock, mockContext);
+        assertTrue(results.isEmpty());
+    }
+    
+    @Nested
+    @DisplayName("Author Validation Tests")
+    class AuthorValidationTests {
+        
+        @Test
+        @DisplayName("should validate required author when missing")
+        void shouldValidateRequiredAuthorWhenMissing() {
+            when(mockNode.getAttribute("author")).thenReturn(null);
+            when(mockNode.getAttribute("attribution")).thenReturn(null);
+            when(mockNode.getAttribute("1")).thenReturn(null);
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .required(true)
+                            .severity(Severity.ERROR)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertEquals(Severity.ERROR, results.get(0).getSeverity());
+            assertTrue(results.get(0).getMessage().contains("requires an author"));
+        }
+        
+        @Test
+        @DisplayName("should validate author min length")
+        void shouldValidateAuthorMinLength() {
+            when(mockNode.getAttribute("author")).thenReturn("AB");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .minLength(3)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertEquals(Severity.WARN, results.get(0).getSeverity());
+            assertTrue(results.get(0).getMessage().contains("too short"));
+            assertTrue(results.get(0).getMessage().contains("minimum 3"));
+            assertTrue(results.get(0).getMessage().contains("found 2"));
+        }
+        
+        @Test
+        @DisplayName("should validate author max length")
+        void shouldValidateAuthorMaxLength() {
+            String longAuthor = "A".repeat(101);
+            when(mockNode.getAttribute("author")).thenReturn(longAuthor);
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.INFO)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .maxLength(100)
+                            .severity(Severity.ERROR)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertEquals(Severity.ERROR, results.get(0).getSeverity());
+            assertTrue(results.get(0).getMessage().contains("too long"));
+            assertTrue(results.get(0).getMessage().contains("maximum 100"));
+            assertTrue(results.get(0).getMessage().contains("found 101"));
+        }
+        
+        @Test
+        @DisplayName("should validate author pattern")
+        void shouldValidateAuthorPattern() {
+            when(mockNode.getAttribute("author")).thenReturn("123 Invalid");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$")
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("does not match required pattern"));
+            assertTrue(results.get(0).getMessage().contains("123 Invalid"));
+        }
+        
+        @Test
+        @DisplayName("should accept valid author")
+        void shouldAcceptValidAuthor() {
+            when(mockNode.getAttribute("author")).thenReturn("John Doe");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .required(true)
+                            .minLength(3)
+                            .maxLength(100)
+                            .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$")
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertTrue(results.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should check multiple author sources")
+        void shouldCheckMultipleAuthorSources() {
+            when(mockNode.getAttribute("author")).thenReturn(null);
+            when(mockNode.getAttribute("attribution")).thenReturn("Jane Smith");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .required(true)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertTrue(results.isEmpty());
+        }
+    }
+    
+    @Nested
+    @DisplayName("Source Validation Tests")
+    class SourceValidationTests {
+        
+        @Test
+        @DisplayName("should validate required source when missing")
+        void shouldValidateRequiredSourceWhenMissing() {
+            when(mockNode.getAttribute("citetitle")).thenReturn(null);
+            when(mockNode.getAttribute("source")).thenReturn(null);
+            when(mockNode.getAttribute("2")).thenReturn(null);
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .source(QuoteBlock.SourceConfig.builder()
+                            .required(true)
+                            .severity(Severity.ERROR)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertEquals(Severity.ERROR, results.get(0).getSeverity());
+            assertTrue(results.get(0).getMessage().contains("requires a source"));
+        }
+        
+        @Test
+        @DisplayName("should validate source pattern")
+        void shouldValidateSourcePattern() {
+            when(mockNode.getAttribute("citetitle")).thenReturn("Book @ Title #123");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .source(QuoteBlock.SourceConfig.builder()
+                            .pattern("^[A-Za-z0-9\\s,\\.\\-\\(\\)]+$")
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("does not match required pattern"));
+        }
+        
+        @Test
+        @DisplayName("should check multiple source attributes")
+        void shouldCheckMultipleSourceAttributes() {
+            when(mockNode.getAttribute("citetitle")).thenReturn(null);
+            when(mockNode.getAttribute("source")).thenReturn(null);
+            when(mockNode.getAttribute("2")).thenReturn("The Great Book");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .source(QuoteBlock.SourceConfig.builder()
+                            .required(true)
+                            .minLength(5)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertTrue(results.isEmpty());
+        }
+    }
+    
+    @Nested
+    @DisplayName("Content Validation Tests")
+    class ContentValidationTests {
+        
+        @Test
+        @DisplayName("should validate required content when missing")
+        void shouldValidateRequiredContentWhenMissing() {
+            when(mockNode.getContent()).thenReturn(null);
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .content(QuoteBlock.ContentConfig.builder()
+                            .required(true)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("requires content"));
+        }
+        
+        @Test
+        @DisplayName("should validate content min length")
+        void shouldValidateContentMinLength() {
+            when(mockNode.getContent()).thenReturn("Short");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .content(QuoteBlock.ContentConfig.builder()
+                            .minLength(20)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("too short"));
+            assertTrue(results.get(0).getMessage().contains("minimum 20"));
+            assertTrue(results.get(0).getMessage().contains("found 5"));
+        }
+        
+        @Test
+        @DisplayName("should validate content max length")
+        void shouldValidateContentMaxLength() {
+            String longContent = "A".repeat(1001);
+            when(mockNode.getContent()).thenReturn(longContent);
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .content(QuoteBlock.ContentConfig.builder()
+                            .maxLength(1000)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("too long"));
+            assertTrue(results.get(0).getMessage().contains("maximum 1000"));
+            assertTrue(results.get(0).getMessage().contains("found 1001"));
+        }
+        
+        @Test
+        @DisplayName("should validate content line count")
+        void shouldValidateContentLineCount() {
+            String multiLineContent = "Line 1\nLine 2\nLine 3";
+            when(mockNode.getContent()).thenReturn(multiLineContent);
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .content(QuoteBlock.ContentConfig.builder()
+                            .lines(QuoteBlock.LinesConfig.builder()
+                                    .min(5)
+                                    .severity(Severity.ERROR)
+                                    .build())
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertEquals(Severity.ERROR, results.get(0).getSeverity());
+            assertTrue(results.get(0).getMessage().contains("too few lines"));
+            assertTrue(results.get(0).getMessage().contains("minimum 5"));
+            assertTrue(results.get(0).getMessage().contains("found 3"));
+        }
+        
+        @Test
+        @DisplayName("should validate max line count")
+        void shouldValidateMaxLineCount() {
+            String manyLines = String.join("\n", "Line".repeat(21).split("(?<=.{4})"));
+            when(mockNode.getContent()).thenReturn(manyLines);
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .content(QuoteBlock.ContentConfig.builder()
+                            .lines(QuoteBlock.LinesConfig.builder()
+                                    .max(20)
+                                    .build())
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertTrue(results.get(0).getMessage().contains("too many lines"));
+        }
+    }
+    
+    @Nested
+    @DisplayName("Severity Hierarchy Tests")
+    class SeverityHierarchyTests {
+        
+        @Test
+        @DisplayName("should use nested severity over block severity")
+        void shouldUseNestedSeverityOverBlockSeverity() {
+            when(mockNode.getAttribute("author")).thenReturn("AB");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.INFO)  // Block level
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .minLength(3)
+                            .severity(Severity.ERROR)  // Nested level
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertEquals(Severity.ERROR, results.get(0).getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should fall back to block severity when nested not specified")
+        void shouldFallBackToBlockSeverity() {
+            when(mockNode.getAttribute("source")).thenReturn("AB");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)  // Block level
+                    .source(QuoteBlock.SourceConfig.builder()
+                            .minLength(3)
+                            // No severity specified
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(1, results.size());
+            assertEquals(Severity.WARN, results.get(0).getSeverity());
+        }
+    }
+    
+    @Nested
+    @DisplayName("Integration Tests")
+    class IntegrationTests {
+        
+        @Test
+        @DisplayName("should validate complete quote block")
+        void shouldValidateCompleteQuoteBlock() {
+            when(mockNode.getAttribute("author")).thenReturn("Albert Einstein");
+            when(mockNode.getAttribute("citetitle")).thenReturn("Theory of Relativity");
+            when(mockNode.getContent()).thenReturn("Imagination is more important than knowledge. " +
+                    "Knowledge is limited. Imagination embraces the entire world, stimulating progress, giving birth to evolution.");
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.INFO)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .required(true)
+                            .minLength(3)
+                            .maxLength(100)
+                            .pattern("^[A-Z][a-zA-Z\\s\\.\\-,]+$")
+                            .severity(Severity.ERROR)
+                            .build())
+                    .source(QuoteBlock.SourceConfig.builder()
+                            .required(false)
+                            .minLength(5)
+                            .maxLength(200)
+                            .build())
+                    .content(QuoteBlock.ContentConfig.builder()
+                            .required(true)
+                            .minLength(20)
+                            .maxLength(1000)
+                            .lines(QuoteBlock.LinesConfig.builder()
+                                    .min(1)
+                                    .max(20)
+                                    .build())
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertTrue(results.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should collect multiple validation errors")
+        void shouldCollectMultipleValidationErrors() {
+            when(mockNode.getAttribute("author")).thenReturn("a");  // Too short
+            when(mockNode.getAttribute("citetitle")).thenReturn("b");  // Too short
+            when(mockNode.getContent()).thenReturn("Short");  // Too short
+            
+            QuoteBlock block = QuoteBlock.builder()
+                    .severity(Severity.WARN)
+                    .author(QuoteBlock.AuthorConfig.builder()
+                            .minLength(3)
+                            .build())
+                    .source(QuoteBlock.SourceConfig.builder()
+                            .minLength(5)
+                            .build())
+                    .content(QuoteBlock.ContentConfig.builder()
+                            .minLength(20)
+                            .build())
+                    .build();
+            
+            List<ValidationMessage> results = validator.validate(mockNode, block, mockContext);
+            
+            assertEquals(3, results.size());
+            assertTrue(results.stream().allMatch(r -> r.getSeverity() == Severity.WARN));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented QUOTE block type for validating AsciiDoc quote blocks
- Added complete validation framework with AuthorConfig, SourceConfig, ContentConfig, and LinesConfig  
- Included comprehensive test coverage and JSON schema definition

## Implementation Details
- **Block Type**: Added `QUOTE` to BlockType enum
- **Configuration**: Created `QuoteBlock` class with nested configuration for author, source, and content validation
- **Validator**: Implemented `QuoteBlockValidator` with support for all quote-specific attributes
- **Detection**: Updated `BlockTypeDetector` to distinguish between QUOTE and VERSE blocks
- **Schema**: Created `quote-block-schema.yaml` following JSON Schema 2020-12
- **Tests**: 38 tests covering configuration, validation, and YAML parsing

## Test plan
- [x] Run all unit tests: `mvn test`
- [x] Verify QUOTE block validation works correctly
- [x] Check YAML configuration parsing for QUOTE blocks  
- [x] Ensure JSON schema validation passes
- [x] Documentation updated with QUOTE block examples

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)