### PR TITLE
#50 Rule Documentation Generator

### DIFF
--- a/src/main/java/com/example/linter/cli/CLIOptions.java
+++ b/src/main/java/com/example/linter/cli/CLIOptions.java
@@ -16,13 +16,12 @@ public class CLIOptions {
     }
     
     private void defineOptions() {
-        // Input patterns (required)
+        // Input patterns (required for validation, optional for doc generation)
         options.addOption(Option.builder("i")
             .longOpt("input")
             .hasArg()
             .argName("patterns")
             .desc("Comma-separated Ant file patterns (e.g., '**/*.adoc,docs/**/*.asciidoc')")
-            .required()
             .build());
         
         // Configuration file
@@ -67,6 +66,20 @@ public class CLIOptions {
         options.addOption(Option.builder("v")
             .longOpt("version")
             .desc("Show version")
+            .build());
+        
+        // Generate documentation
+        options.addOption(Option.builder()
+            .longOpt("generate-docs")
+            .desc("Generate human-readable documentation from configuration")
+            .build());
+        
+        // Visualization style for documentation
+        options.addOption(Option.builder()
+            .longOpt("viz-style")
+            .hasArg()
+            .argName("styles")
+            .desc("Comma-separated visualization styles: tree, nested, breadcrumb, table (default: tree)")
             .build());
     }
     

--- a/src/main/java/com/example/linter/cli/DocumentationGeneratorRunner.java
+++ b/src/main/java/com/example/linter/cli/DocumentationGeneratorRunner.java
@@ -1,0 +1,115 @@
+package com.example.linter.cli;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.cli.CommandLine;
+
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.loader.ConfigurationLoader;
+import com.example.linter.documentation.AsciiDocRuleGenerator;
+import com.example.linter.documentation.RuleDocumentationGenerator;
+import com.example.linter.documentation.VisualizationStyle;
+
+/**
+ * Runner for generating documentation from linter configuration.
+ */
+public class DocumentationGeneratorRunner {
+    
+    private final ConfigurationLoader configLoader;
+    
+    public DocumentationGeneratorRunner() {
+        this.configLoader = new ConfigurationLoader();
+    }
+    
+    /**
+     * Generates documentation based on CLI arguments.
+     * 
+     * @param cmd the parsed command line
+     * @return exit code (0 for success, non-zero for error)
+     */
+    public int run(CommandLine cmd) {
+        try {
+            // Load configuration
+            String configPath = cmd.getOptionValue("config", ".linter-config.yaml");
+            LinterConfiguration config = loadConfiguration(configPath);
+            
+            // Parse visualization styles
+            Set<VisualizationStyle> styles = parseVisualizationStyles(cmd.getOptionValue("viz-style"));
+            
+            // Create generator
+            RuleDocumentationGenerator generator = new AsciiDocRuleGenerator(styles);
+            
+            // Determine output
+            String outputPath = cmd.getOptionValue("report-output");
+            
+            if (outputPath != null) {
+                // Write to file
+                generateToFile(generator, config, outputPath);
+                System.out.println("Documentation generated successfully: " + outputPath);
+            } else {
+                // Write to stdout
+                generateToStdout(generator, config);
+            }
+            
+            return 0;
+            
+        } catch (Exception e) {
+            System.err.println("Error generating documentation: " + e.getMessage());
+            return 2;
+        }
+    }
+    
+    private LinterConfiguration loadConfiguration(String configPath) throws IOException {
+        File configFile = new File(configPath);
+        if (!configFile.exists()) {
+            throw new IOException("Configuration file not found: " + configPath);
+        }
+        
+        return configLoader.loadConfiguration(configFile.toPath());
+    }
+    
+    private Set<VisualizationStyle> parseVisualizationStyles(String stylesArg) {
+        if (stylesArg == null || stylesArg.trim().isEmpty()) {
+            // Default to tree visualization
+            return Set.of(VisualizationStyle.TREE);
+        }
+        
+        return Arrays.stream(stylesArg.split(","))
+            .map(String::trim)
+            .map(VisualizationStyle::fromName)
+            .collect(Collectors.toSet());
+    }
+    
+    private void generateToFile(RuleDocumentationGenerator generator, 
+                               LinterConfiguration config, 
+                               String outputPath) throws IOException {
+        
+        File outputFile = new File(outputPath);
+        
+        // Create parent directories if needed
+        File parentDir = outputFile.getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            if (!parentDir.mkdirs()) {
+                throw new IOException("Failed to create output directory: " + parentDir);
+            }
+        }
+        
+        try (PrintWriter writer = new PrintWriter(new FileWriter(outputFile))) {
+            generator.generate(config, writer);
+        }
+    }
+    
+    private void generateToStdout(RuleDocumentationGenerator generator, 
+                                 LinterConfiguration config) {
+        PrintWriter writer = new PrintWriter(System.out);
+        generator.generate(config, writer);
+        writer.flush();
+    }
+}

--- a/src/main/java/com/example/linter/cli/LinterCLI.java
+++ b/src/main/java/com/example/linter/cli/LinterCLI.java
@@ -51,6 +51,25 @@ public class LinterCLI {
                 return 0;
             }
             
+            // Handle documentation generation
+            if (cmd.hasOption("generate-docs")) {
+                // Input is not required for doc generation
+                if (!cmd.hasOption("config")) {
+                    System.err.println("Error: --config is required when using --generate-docs");
+                    return 2;
+                }
+                
+                DocumentationGeneratorRunner docRunner = new DocumentationGeneratorRunner();
+                return docRunner.run(cmd);
+            }
+            
+            // For normal validation, input is required
+            if (!cmd.hasOption("input")) {
+                System.err.println("Error: --input is required for validation");
+                printHelp(options);
+                return 2;
+            }
+            
             // Parse configuration
             CLIConfig config = parseConfiguration(cmd);
             

--- a/src/main/java/com/example/linter/documentation/AsciiDocRuleGenerator.java
+++ b/src/main/java/com/example/linter/documentation/AsciiDocRuleGenerator.java
@@ -1,0 +1,356 @@
+package com.example.linter.documentation;
+
+import java.io.PrintWriter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import com.example.linter.config.DocumentConfiguration;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.MetadataConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.config.rule.AttributeConfig;
+import com.example.linter.config.rule.SectionConfig;
+
+/**
+ * Generates AsciiDoc documentation from linter configuration rules.
+ * 
+ * <p>This generator creates human-readable documentation in AsciiDoc format,
+ * suitable for content authors who need to understand the validation rules
+ * for their documents.</p>
+ */
+public class AsciiDocRuleGenerator implements RuleDocumentationGenerator {
+    
+    private final Set<VisualizationStyle> visualizationStyles;
+    private final PatternHumanizer patternHumanizer;
+    private final HierarchyVisualizerFactory visualizerFactory;
+    
+    /**
+     * Creates a new AsciiDoc rule generator with default visualization styles.
+     */
+    public AsciiDocRuleGenerator() {
+        this(Set.of(VisualizationStyle.TREE));
+    }
+    
+    /**
+     * Creates a new AsciiDoc rule generator with specified visualization styles.
+     * 
+     * @param visualizationStyles the visualization styles to use
+     */
+    public AsciiDocRuleGenerator(Set<VisualizationStyle> visualizationStyles) {
+        this.visualizationStyles = new HashSet<>(visualizationStyles);
+        this.patternHumanizer = new PatternHumanizer();
+        this.visualizerFactory = new HierarchyVisualizerFactory();
+    }
+    
+    @Override
+    public void generate(LinterConfiguration config, PrintWriter writer) {
+        Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(writer, "writer must not be null");
+        
+        generateHeader(writer);
+        generateIntroduction(writer);
+        generateMetadataSection(config.document().metadata(), writer);
+        generateStructureSection(config.document(), writer);
+        generateBlockReferenceSection(config.document(), writer);
+        generateValidationLevelsSection(writer);
+        generateTipsSection(writer);
+    }
+    
+    @Override
+    public DocumentationFormat getFormat() {
+        return DocumentationFormat.ASCIIDOC;
+    }
+    
+    @Override
+    public String getName() {
+        return "AsciiDoc Rule Documentation Generator";
+    }
+    
+    private void generateHeader(PrintWriter writer) {
+        writer.println("= AsciiDoc Dokument-Richtlinien");
+        writer.println(":toc: left");
+        writer.println(":toclevels: 3");
+        writer.println(":icons: font");
+        writer.println(":source-highlighter: rouge");
+        writer.println();
+    }
+    
+    private void generateIntroduction(PrintWriter writer) {
+        writer.println("== Einführung");
+        writer.println();
+        writer.println("Diese Richtlinien beschreiben die Anforderungen für AsciiDoc-Dokumente in diesem Projekt.");
+        writer.println("Alle Dokumente werden automatisch gegen diese Regeln validiert.");
+        writer.println();
+    }
+    
+    private void generateMetadataSection(MetadataConfiguration metadata, PrintWriter writer) {
+        if (metadata == null || metadata.attributes() == null || metadata.attributes().isEmpty()) {
+            return;
+        }
+        
+        writer.println("== Dokument-Metadaten");
+        writer.println();
+        writer.println("Jedes Dokument muss die folgenden Metadaten-Attribute definieren:");
+        writer.println();
+        
+        // Separate required and optional attributes
+        List<AttributeConfig> requiredAttrs = metadata.attributes().stream()
+            .filter(AttributeConfig::required)
+            .toList();
+        
+        List<AttributeConfig> optionalAttrs = metadata.attributes().stream()
+            .filter(attr -> !attr.required())
+            .toList();
+        
+        if (!requiredAttrs.isEmpty()) {
+            writer.println("=== Pflichtattribute");
+            writer.println();
+            generateAttributeTable(requiredAttrs, writer);
+        }
+        
+        if (!optionalAttrs.isEmpty()) {
+            writer.println("=== Optionale Attribute");
+            writer.println();
+            generateAttributeTable(optionalAttrs, writer);
+        }
+    }
+    
+    private void generateAttributeTable(List<AttributeConfig> attributes, PrintWriter writer) {
+        writer.println("[cols=\"1,2,1,3\", options=\"header\"]");
+        writer.println("|===");
+        writer.println("|Attribut |Beschreibung |Schweregrad |Anforderungen");
+        writer.println();
+        
+        for (AttributeConfig attr : attributes) {
+            writer.println("|" + attr.name());
+            writer.println("|" + getAttributeDescription(attr));
+            writer.println("|" + formatSeverity(attr.severity()));
+            writer.println("a|");
+            generateAttributeRequirements(attr, writer);
+            writer.println();
+        }
+        
+        writer.println("|===");
+        writer.println();
+    }
+    
+    private void generateAttributeRequirements(AttributeConfig attr, PrintWriter writer) {
+        if (attr.required()) {
+            writer.println("* Pflichtfeld");
+        } else {
+            writer.println("* Optional");
+        }
+        
+        if (attr.minLength() != null) {
+            writer.println("* Mindestlänge: " + attr.minLength() + " Zeichen");
+        }
+        
+        if (attr.maxLength() != null) {
+            writer.println("* Maximallänge: " + attr.maxLength() + " Zeichen");
+        }
+        
+        if (attr.pattern() != null) {
+            writer.println("* Format: " + patternHumanizer.humanize(attr.pattern()));
+        }
+        
+        // TODO: Add support for allowed values when available in AttributeConfig
+        
+        writer.println("* Beispiel: `:" + attr.name() + ": " + generateAttributeExample(attr) + "`");
+    }
+    
+    private void generateStructureSection(DocumentConfiguration document, PrintWriter writer) {
+        writer.println("== Dokumentstruktur");
+        writer.println();
+        
+        // Generate hierarchy visualization based on selected styles
+        for (VisualizationStyle style : visualizationStyles) {
+            HierarchyVisualizer visualizer = visualizerFactory.create(style);
+            writer.println("=== " + style.getDescription());
+            writer.println();
+            visualizer.visualize(LinterConfiguration.builder().document(document).build(), writer);
+            writer.println();
+        }
+        
+        // Generate detailed section documentation
+        if (document.sections() != null && !document.sections().isEmpty()) {
+            writer.println("== Abschnitt-Details");
+            writer.println();
+            
+            for (SectionConfig section : document.sections()) {
+                generateSectionDetails(section, writer);
+            }
+        }
+    }
+    
+    private void generateSectionDetails(SectionConfig section, PrintWriter writer) {
+        writer.println("=== Abschnitt: " + section.name());
+        writer.println();
+        
+        generateSectionNote(section, writer);
+        
+        if (section.allowedBlocks() != null && !section.allowedBlocks().isEmpty()) {
+            writer.println(".Erlaubte Inhalte");
+            writer.println("[cols=\"1,3\", options=\"header\"]");
+            writer.println("|===");
+            writer.println("|Block-Typ |Anforderungen");
+            writer.println();
+            
+            for (Block block : section.allowedBlocks()) {
+                writer.println("|" + formatBlockType(block));
+                writer.println("a|");
+                generateBlockSummary(block, writer);
+                writer.println();
+            }
+            
+            writer.println("|===");
+            writer.println();
+        }
+        
+        generateSectionExample(section, writer);
+        
+        // Generate subsections
+        if (section.subsections() != null && !section.subsections().isEmpty()) {
+            for (SectionConfig subsection : section.subsections()) {
+                generateSectionDetails(subsection, writer);
+            }
+        }
+    }
+    
+    private void generateSectionNote(SectionConfig section, PrintWriter writer) {
+        String severity = section.min() > 0 ? "CAUTION" : "NOTE";
+        
+        writer.println("[" + severity + "]");
+        writer.println("====");
+        writer.println("**Position**: " + (section.order() != null ? 
+            "Position " + section.order() : "Beliebig"));
+        writer.println("**Level**: " + section.level());
+        writer.println("**Pflicht**: " + (section.min() > 0 ? "Ja" : "Nein"));
+        
+        writer.print("**Anzahl**: ");
+        if (section.max() > 0) {
+            writer.println(section.min() + "-" + section.max());
+        } else {
+            writer.println("Mindestens " + section.min());
+        }
+        
+        writer.println("====");
+        writer.println();
+    }
+    
+    private void generateBlockReferenceSection(DocumentConfiguration document, PrintWriter writer) {
+        writer.println("== Block-Referenz");
+        writer.println();
+        writer.println("Detaillierte Beschreibung aller verfügbaren Block-Typen und ihrer Validierungsregeln.");
+        writer.println();
+        
+        // TODO: Collect all unique block types from configuration and generate detailed docs
+    }
+    
+    private void generateValidationLevelsSection(PrintWriter writer) {
+        writer.println("== Validierungsstufen");
+        writer.println();
+        
+        writer.println("[cols=\"1,1,3\", options=\"header\"]");
+        writer.println("|===");
+        writer.println("|Stufe |Symbol |Bedeutung");
+        writer.println();
+        writer.println("|ERROR");
+        writer.println("|icon:times-circle[role=\"red\"]");
+        writer.println("|Dokument wird abgelehnt, muss korrigiert werden");
+        writer.println();
+        writer.println("|WARN");
+        writer.println("|icon:exclamation-triangle[role=\"yellow\"]");
+        writer.println("|Sollte behoben werden, Dokument wird aber akzeptiert");
+        writer.println();
+        writer.println("|INFO");
+        writer.println("|icon:info-circle[role=\"blue\"]");
+        writer.println("|Hinweis zur Verbesserung, optional");
+        writer.println("|===");
+        writer.println();
+    }
+    
+    private void generateTipsSection(PrintWriter writer) {
+        writer.println("== Tipps für Autoren");
+        writer.println();
+        writer.println("TIP: Nutzen Sie den Linter während des Schreibens mit `--watch` Modus.");
+        writer.println();
+        writer.println("TIP: Die Fehlermeldungen enthalten immer die erwarteten Werte.");
+        writer.println();
+        writer.println("IMPORTANT: Bei Fragen zu den Regeln wenden Sie sich an das Documentation Team.");
+        writer.println();
+    }
+    
+    // Helper methods
+    private String getAttributeDescription(AttributeConfig attr) {
+        // TODO: Load from schema or generate based on name
+        return switch (attr.name()) {
+            case "title" -> "Dokumenttitel";
+            case "author" -> "Autor des Dokuments";
+            case "version" -> "Dokumentversion";
+            case "email" -> "Kontakt E-Mail";
+            default -> attr.name();
+        };
+    }
+    
+    private String formatSeverity(Severity severity) {
+        return severity.name();
+    }
+    
+    private String generateAttributeExample(AttributeConfig attr) {
+        return switch (attr.name()) {
+            case "title" -> "Benutzerhandbuch für Power AsciiDoc Linter";
+            case "author" -> "Max Mustermann";
+            case "version" -> "1.0.0";
+            case "email" -> "autor@beispiel.de";
+            default -> "Beispielwert";
+        };
+    }
+    
+    private String formatBlockType(Block block) {
+        return block.getType().toValue();
+    }
+    
+    private void generateBlockSummary(Block block, PrintWriter writer) {
+        // TODO: Generate summary based on block type
+        writer.println("* Anzahl: " + getOccurrenceText(block));
+        if (block.getSeverity() != null) {
+            writer.println("* Schweregrad: " + block.getSeverity());
+        }
+    }
+    
+    private String getOccurrenceText(Block block) {
+        if (block.getOccurrence() == null) {
+            return "Beliebig";
+        }
+        
+        Integer min = block.getOccurrence().min();
+        Integer max = block.getOccurrence().max();
+        
+        if (min != null && max != null) {
+            return min + "-" + max;
+        } else if (min != null) {
+            return "Mindestens " + min;
+        } else if (max != null) {
+            return "Maximal " + max;
+        }
+        return "Beliebig";
+    }
+    
+    private void generateSectionExample(SectionConfig section, PrintWriter writer) {
+        writer.println(".Beispiel");
+        writer.println("[source,asciidoc]");
+        writer.println("----");
+        
+        // Generate example based on section level
+        String prefix = "=".repeat(section.level() + 1);
+        writer.println(prefix + " " + section.name());
+        writer.println();
+        writer.println("Beispielinhalt für diesen Abschnitt.");
+        
+        writer.println("----");
+        writer.println();
+    }
+}

--- a/src/main/java/com/example/linter/documentation/DocumentationFormat.java
+++ b/src/main/java/com/example/linter/documentation/DocumentationFormat.java
@@ -1,0 +1,32 @@
+package com.example.linter.documentation;
+
+/**
+ * Supported documentation output formats.
+ */
+public enum DocumentationFormat {
+    ASCIIDOC(".adoc", "AsciiDoc", "text/asciidoc"),
+    MARKDOWN(".md", "Markdown", "text/markdown"),
+    HTML(".html", "HTML", "text/html");
+    
+    private final String extension;
+    private final String displayName;
+    private final String mimeType;
+    
+    DocumentationFormat(String extension, String displayName, String mimeType) {
+        this.extension = extension;
+        this.displayName = displayName;
+        this.mimeType = mimeType;
+    }
+    
+    public String getExtension() {
+        return extension;
+    }
+    
+    public String getDisplayName() {
+        return displayName;
+    }
+    
+    public String getMimeType() {
+        return mimeType;
+    }
+}

--- a/src/main/java/com/example/linter/documentation/HierarchyVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/HierarchyVisualizer.java
@@ -1,0 +1,26 @@
+package com.example.linter.documentation;
+
+import java.io.PrintWriter;
+
+import com.example.linter.config.LinterConfiguration;
+
+/**
+ * Interface for visualizing rule hierarchies in documentation.
+ */
+public interface HierarchyVisualizer {
+    
+    /**
+     * Visualizes the rule hierarchy from the given configuration.
+     * 
+     * @param config the linter configuration
+     * @param writer the output writer
+     */
+    void visualize(LinterConfiguration config, PrintWriter writer);
+    
+    /**
+     * Returns the visualization style this visualizer implements.
+     * 
+     * @return the visualization style
+     */
+    VisualizationStyle getStyle();
+}

--- a/src/main/java/com/example/linter/documentation/HierarchyVisualizerFactory.java
+++ b/src/main/java/com/example/linter/documentation/HierarchyVisualizerFactory.java
@@ -1,0 +1,55 @@
+package com.example.linter.documentation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.example.linter.documentation.visualizers.BreadcrumbVisualizer;
+import com.example.linter.documentation.visualizers.NestedListVisualizer;
+import com.example.linter.documentation.visualizers.TableVisualizer;
+import com.example.linter.documentation.visualizers.TreeVisualizer;
+
+/**
+ * Factory for creating hierarchy visualizers.
+ */
+public class HierarchyVisualizerFactory {
+    
+    private final Map<VisualizationStyle, HierarchyVisualizer> visualizers;
+    
+    public HierarchyVisualizerFactory() {
+        this.visualizers = new HashMap<>();
+        registerVisualizers();
+    }
+    
+    private void registerVisualizers() {
+        visualizers.put(VisualizationStyle.TREE, new TreeVisualizer());
+        visualizers.put(VisualizationStyle.NESTED, new NestedListVisualizer());
+        visualizers.put(VisualizationStyle.BREADCRUMB, new BreadcrumbVisualizer());
+        visualizers.put(VisualizationStyle.TABLE, new TableVisualizer());
+        // TODO: Add PlantUML and SeverityFlow visualizers
+    }
+    
+    /**
+     * Creates a visualizer for the specified style.
+     * 
+     * @param style the visualization style
+     * @return the visualizer
+     * @throws IllegalArgumentException if no visualizer exists for the style
+     */
+    public HierarchyVisualizer create(VisualizationStyle style) {
+        HierarchyVisualizer visualizer = visualizers.get(style);
+        if (visualizer == null) {
+            throw new IllegalArgumentException("No visualizer available for style: " + style);
+        }
+        return visualizer;
+    }
+    
+    /**
+     * Checks if a visualizer is available for the specified style.
+     * 
+     * @param style the visualization style
+     * @return true if a visualizer exists, false otherwise
+     */
+    public boolean hasVisualizer(VisualizationStyle style) {
+        return visualizers.containsKey(style);
+    }
+}

--- a/src/main/java/com/example/linter/documentation/PatternHumanizer.java
+++ b/src/main/java/com/example/linter/documentation/PatternHumanizer.java
@@ -1,0 +1,137 @@
+package com.example.linter.documentation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Converts regular expression patterns into human-readable descriptions.
+ */
+public class PatternHumanizer {
+    
+    private final Map<String, String> knownPatterns;
+    
+    public PatternHumanizer() {
+        this.knownPatterns = new HashMap<>();
+        initializeKnownPatterns();
+    }
+    
+    private void initializeKnownPatterns() {
+        // Common patterns
+        knownPatterns.put("^[A-Z].*", "Muss mit einem Großbuchstaben beginnen");
+        knownPatterns.put("^[a-z].*", "Muss mit einem Kleinbuchstaben beginnen");
+        knownPatterns.put("^\\d+\\.\\d+\\.\\d+$", "Semantic Versioning Format (z.B. 1.0.0)");
+        knownPatterns.put("^[\\w._%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$", "Gültige E-Mail-Adresse");
+        
+        // URL patterns
+        knownPatterns.put("^https?://.*", "Muss mit http:// oder https:// beginnen");
+        knownPatterns.put(".*\\.(png|jpg|jpeg|gif|svg)$", "Bilddatei (PNG, JPG, JPEG, GIF oder SVG)");
+        knownPatterns.put(".*\\.(mp3|ogg|wav|m4a)$", "Audiodatei (MP3, OGG, WAV oder M4A)");
+        
+        // Title patterns
+        knownPatterns.put("^(Introduction|Einführung)$", "Muss 'Introduction' oder 'Einführung' sein");
+        knownPatterns.put("^Listing \\d+:.*", "Muss mit 'Listing' gefolgt von einer Nummer und Doppelpunkt beginnen");
+        knownPatterns.put("^Table \\d+:.*", "Muss mit 'Table' gefolgt von einer Nummer und Doppelpunkt beginnen");
+        knownPatterns.put("^Figure \\d+:.*", "Muss mit 'Figure' gefolgt von einer Nummer und Doppelpunkt beginnen");
+        
+        // Language patterns
+        knownPatterns.put("^(java|python|javascript|yaml|json|xml)$", "Erlaubte Sprachen: java, python, javascript, yaml, json, xml");
+    }
+    
+    /**
+     * Converts a regex pattern to a human-readable description.
+     * 
+     * @param pattern the pattern to humanize
+     * @return a human-readable description
+     */
+    public String humanize(Pattern pattern) {
+        if (pattern == null) {
+            return "";
+        }
+        return humanize(pattern.pattern());
+    }
+    
+    /**
+     * Converts a regex pattern string to a human-readable description.
+     * 
+     * @param patternString the pattern string to humanize
+     * @return a human-readable description
+     */
+    public String humanize(String patternString) {
+        if (patternString == null || patternString.isEmpty()) {
+            return "";
+        }
+        
+        // Check known patterns first
+        String known = knownPatterns.get(patternString);
+        if (known != null) {
+            return known;
+        }
+        
+        // Try to generate description for common patterns
+        String description = generateDescription(patternString);
+        if (description != null) {
+            return description;
+        }
+        
+        // Fallback: show the pattern itself
+        return "Muss dem Muster entsprechen: " + patternString;
+    }
+    
+    private String generateDescription(String pattern) {
+        // Handle file extensions
+        if (pattern.matches(".*\\\\\\.(\\w+\\|)*\\w+\\)\\$")) {
+            String extensions = pattern.replaceAll(".*\\\\\\.(\\()?", "")
+                                     .replaceAll("\\)\\$", "")
+                                     .replaceAll("\\|", ", ");
+            return "Dateiendung muss sein: " + extensions.toUpperCase();
+        }
+        
+        // Handle simple starts-with patterns
+        if (pattern.startsWith("^") && !pattern.contains("$")) {
+            String prefix = pattern.substring(1).replaceAll("\\\\_", "_");
+            if (!prefix.contains("[") && !prefix.contains("(")) {
+                return "Muss mit '" + prefix + "' beginnen";
+            }
+        }
+        
+        // Handle simple ends-with patterns
+        if (pattern.endsWith("$") && !pattern.startsWith("^")) {
+            String suffix = pattern.substring(0, pattern.length() - 1);
+            if (!suffix.contains("[") && !suffix.contains("(")) {
+                return "Muss mit '" + suffix + "' enden";
+            }
+        }
+        
+        // Handle exact match patterns
+        if (pattern.startsWith("^") && pattern.endsWith("$")) {
+            String exact = pattern.substring(1, pattern.length() - 1);
+            if (!exact.contains("[") && !exact.contains("(") && !exact.contains("*") && !exact.contains("+")) {
+                return "Muss genau '" + exact + "' sein";
+            }
+        }
+        
+        // Handle character class patterns
+        if (pattern.equals("^[A-Za-z]+$")) {
+            return "Nur Buchstaben erlaubt";
+        }
+        if (pattern.equals("^[0-9]+$")) {
+            return "Nur Zahlen erlaubt";
+        }
+        if (pattern.equals("^[A-Za-z0-9]+$")) {
+            return "Nur Buchstaben und Zahlen erlaubt";
+        }
+        
+        return null;
+    }
+    
+    /**
+     * Registers a custom pattern description.
+     * 
+     * @param pattern the regex pattern
+     * @param description the human-readable description
+     */
+    public void registerPattern(String pattern, String description) {
+        knownPatterns.put(pattern, description);
+    }
+}

--- a/src/main/java/com/example/linter/documentation/RuleDocumentationGenerator.java
+++ b/src/main/java/com/example/linter/documentation/RuleDocumentationGenerator.java
@@ -1,0 +1,36 @@
+package com.example.linter.documentation;
+
+import java.io.PrintWriter;
+
+import com.example.linter.config.LinterConfiguration;
+
+/**
+ * Interface for generating human-readable documentation from linter configuration rules.
+ * 
+ * <p>Implementations of this interface convert YAML-based linter rules into
+ * documentation formats suitable for content authors.</p>
+ */
+public interface RuleDocumentationGenerator {
+    
+    /**
+     * Generates documentation from the given linter configuration.
+     * 
+     * @param config the linter configuration containing all rules
+     * @param writer the writer to output the documentation to
+     */
+    void generate(LinterConfiguration config, PrintWriter writer);
+    
+    /**
+     * Returns the documentation format this generator produces.
+     * 
+     * @return the documentation format
+     */
+    DocumentationFormat getFormat();
+    
+    /**
+     * Returns the name of this generator for display purposes.
+     * 
+     * @return the generator name
+     */
+    String getName();
+}

--- a/src/main/java/com/example/linter/documentation/VisualizationStyle.java
+++ b/src/main/java/com/example/linter/documentation/VisualizationStyle.java
@@ -1,0 +1,38 @@
+package com.example.linter.documentation;
+
+/**
+ * Available visualization styles for rule hierarchy documentation.
+ */
+public enum VisualizationStyle {
+    TREE("tree", "ASCII-art tree structure"),
+    NESTED("nested", "Nested lists with severity indicators"),
+    BREADCRUMB("breadcrumb", "Path-style representation"),
+    TABLE("table", "Hierarchical table with indentation"),
+    PLANTUML("plantuml", "PlantUML diagram"),
+    SEVERITY_FLOW("severity-flow", "Severity inheritance visualization");
+    
+    private final String name;
+    private final String description;
+    
+    VisualizationStyle(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public static VisualizationStyle fromName(String name) {
+        for (VisualizationStyle style : values()) {
+            if (style.name.equalsIgnoreCase(name)) {
+                return style;
+            }
+        }
+        throw new IllegalArgumentException("Unknown visualization style: " + name);
+    }
+}

--- a/src/main/java/com/example/linter/documentation/visualizers/BreadcrumbVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/BreadcrumbVisualizer.java
@@ -1,0 +1,193 @@
+package com.example.linter.documentation.visualizers;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.example.linter.config.DocumentConfiguration;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.MetadataConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.AttributeConfig;
+import com.example.linter.config.rule.SectionConfig;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.documentation.HierarchyVisualizer;
+import com.example.linter.documentation.VisualizationStyle;
+
+/**
+ * Visualizes rule hierarchy as breadcrumb paths.
+ */
+public class BreadcrumbVisualizer implements HierarchyVisualizer {
+    
+    private static class RulePath {
+        final String path;
+        final Severity severity;
+        final String description;
+        
+        RulePath(String path, Severity severity, String description) {
+            this.path = path;
+            this.severity = severity;
+            this.description = description;
+        }
+    }
+    
+    @Override
+    public void visualize(LinterConfiguration config, PrintWriter writer) {
+        List<RulePath> paths = collectAllPaths(config.document());
+        
+        writer.println("[%header,cols=\"3,1,2\"]");
+        writer.println("|===");
+        writer.println("|Regel-Pfad |Severity |Beschreibung");
+        writer.println();
+        
+        for (RulePath path : paths) {
+            writer.println("|`" + path.path + "`");
+            writer.println("|" + path.severity);
+            writer.println("|" + path.description);
+            writer.println();
+        }
+        
+        writer.println("|===");
+    }
+    
+    @Override
+    public VisualizationStyle getStyle() {
+        return VisualizationStyle.BREADCRUMB;
+    }
+    
+    private List<RulePath> collectAllPaths(DocumentConfiguration doc) {
+        List<RulePath> paths = new ArrayList<>();
+        
+        // Add document root
+        paths.add(new RulePath("document", null, "Dokument-Wurzel"));
+        
+        // Collect metadata paths
+        if (doc.metadata() != null) {
+            collectMetadataPaths(doc.metadata(), "document", paths);
+        }
+        
+        // Collect section paths
+        if (doc.sections() != null) {
+            paths.add(new RulePath("document > sections", Severity.ERROR, 
+                                  "Abschnitte (mindestens einer erforderlich)"));
+            
+            for (SectionConfig section : doc.sections()) {
+                collectSectionPaths(section, "document > sections", paths);
+            }
+        }
+        
+        return paths;
+    }
+    
+    private void collectMetadataPaths(MetadataConfiguration metadata, String parentPath, 
+                                     List<RulePath> paths) {
+        String metadataPath = parentPath + " > metadata";
+        paths.add(new RulePath(metadataPath, Severity.ERROR, "Metadaten-Container (Pflicht)"));
+        
+        if (metadata.attributes() != null) {
+            for (AttributeConfig attr : metadata.attributes()) {
+                String attrPath = metadataPath + " > " + attr.name();
+                String description = getAttributeDescription(attr) + 
+                                   " (" + (attr.required() ? "Pflichtfeld" : "Optional") + ")";
+                paths.add(new RulePath(attrPath, attr.severity(), description));
+            }
+        }
+    }
+    
+    private void collectSectionPaths(SectionConfig section, String parentPath, 
+                                    List<RulePath> paths) {
+        String sectionPath = parentPath + " > " + section.name();
+        String description = getSectionDescription(section) + 
+                           " (Level " + section.level() + ")";
+        Severity severity = section.min() > 0 ? 
+                          Severity.ERROR : Severity.INFO;
+        
+        paths.add(new RulePath(sectionPath, severity, description));
+        
+        // Collect allowed blocks
+        if (section.allowedBlocks() != null && !section.allowedBlocks().isEmpty()) {
+            String blocksPath = sectionPath + " > allowedBlocks";
+            paths.add(new RulePath(blocksPath, null, "Erlaubte Block-Typen"));
+            
+            for (Block block : section.allowedBlocks()) {
+                collectBlockPaths(block, blocksPath, paths);
+            }
+        }
+        
+        // Collect subsections
+        if (section.subsections() != null && !section.subsections().isEmpty()) {
+            String subsectionsPath = sectionPath + " > subsections";
+            paths.add(new RulePath(subsectionsPath, null, "Unterabschnitte"));
+            
+            for (SectionConfig subsection : section.subsections()) {
+                collectSectionPaths(subsection, subsectionsPath, paths);
+            }
+        }
+    }
+    
+    private void collectBlockPaths(Block block, String parentPath, List<RulePath> paths) {
+        String blockPath = parentPath + " > " + block.getType().toValue();
+        String description = getBlockDescription(block);
+        
+        paths.add(new RulePath(blockPath, block.getSeverity(), description));
+        
+        // Add block-specific rule paths
+        collectBlockRulePaths(block, blockPath, paths);
+    }
+    
+    private void collectBlockRulePaths(Block block, String blockPath, List<RulePath> paths) {
+        // TODO: Add specific rule paths based on block type
+        // For example, for AudioBlock:
+        // - blockPath > url
+        // - blockPath > options > autoplay
+        // - blockPath > options > controls
+        // - blockPath > title
+        
+        if (block.getOccurrence() != null) {
+            String occurrencePath = blockPath + " > occurrence";
+            String description = "Anzahl-Beschränkungen";
+            Severity severity = block.getOccurrence().severity() != null ? 
+                              block.getOccurrence().severity() : block.getSeverity();
+            paths.add(new RulePath(occurrencePath, severity, description));
+        }
+    }
+    
+    private String getAttributeDescription(AttributeConfig attr) {
+        return switch (attr.name()) {
+            case "title" -> "Dokumenttitel";
+            case "author" -> "Verfasser";
+            case "version" -> "Versionsnummer";
+            case "email" -> "Kontakt-E-Mail";
+            default -> attr.name();
+        };
+    }
+    
+    private String getSectionDescription(SectionConfig section) {
+        return switch (section.name()) {
+            case "introduction" -> "Einführungsabschnitt";
+            case "implementation" -> "Implementierungsdetails";
+            case "conclusion" -> "Zusammenfassung";
+            default -> section.name();
+        };
+    }
+    
+    private String getBlockDescription(Block block) {
+        String desc = switch (block.getType()) {
+            case PARAGRAPH -> "Text-Absätze";
+            case LISTING -> "Code-Blöcke";
+            case TABLE -> "Tabellen";
+            case IMAGE -> "Bilder";
+            case VERSE -> "Zitate/Verse";
+            case ADMONITION -> "Hinweise/Warnungen";
+            case PASS -> "Pass-Through-Blöcke";
+            case LITERAL -> "Literale Blöcke";
+            default -> "Block-Typ " + block.getType().toValue();
+        };
+        
+        if (block.getName() != null) {
+            desc += " (" + block.getName() + ")";
+        }
+        
+        return desc;
+    }
+}

--- a/src/main/java/com/example/linter/documentation/visualizers/NestedListVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/NestedListVisualizer.java
@@ -1,0 +1,185 @@
+package com.example.linter.documentation.visualizers;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+import com.example.linter.config.DocumentConfiguration;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.MetadataConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.AttributeConfig;
+import com.example.linter.config.rule.SectionConfig;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.documentation.HierarchyVisualizer;
+import com.example.linter.documentation.VisualizationStyle;
+
+/**
+ * Visualizes rule hierarchy as nested lists with severity indicators.
+ */
+public class NestedListVisualizer implements HierarchyVisualizer {
+    
+    @Override
+    public void visualize(LinterConfiguration config, PrintWriter writer) {
+        writer.println("=== icon:file-alt[] Dokument-Ebene");
+        writer.println();
+        
+        DocumentConfiguration doc = config.document();
+        if (doc.metadata() != null) {
+            visualizeMetadata(doc.metadata(), writer);
+        }
+        
+        if (doc.sections() != null && !doc.sections().isEmpty()) {
+            visualizeSections(doc.sections(), "", writer);
+        }
+    }
+    
+    @Override
+    public VisualizationStyle getStyle() {
+        return VisualizationStyle.NESTED;
+    }
+    
+    private void visualizeMetadata(MetadataConfiguration metadata, PrintWriter writer) {
+        writer.println("* " + getSeverityIcon(Severity.ERROR) + " **metadata** _(Pflicht)_");
+        
+        if (metadata.attributes() != null) {
+            for (AttributeConfig attr : metadata.attributes()) {
+                String icon = getSeverityIcon(attr.severity());
+                String required = attr.required() ? "Pflichtfeld" : "Optional";
+                
+                writer.println("** " + icon + " **" + attr.name() + "** - " + getAttributeDescription(attr));
+                writer.println("*** " + required);
+                
+                if (attr.minLength() != null || attr.maxLength() != null) {
+                    writer.print("*** ");
+                    if (attr.minLength() != null) {
+                        writer.print("Min: " + attr.minLength());
+                    }
+                    if (attr.minLength() != null && attr.maxLength() != null) {
+                        writer.print(", ");
+                    }
+                    if (attr.maxLength() != null) {
+                        writer.print("Max: " + attr.maxLength());
+                    }
+                    writer.println(" Zeichen");
+                }
+                
+                if (attr.pattern() != null) {
+                    writer.println("*** Muster: " + attr.pattern());
+                }
+            }
+        }
+        writer.println();
+    }
+    
+    private void visualizeSections(List<SectionConfig> sections, String indent, 
+                                  PrintWriter writer) {
+        writer.println(indent + "* icon:folder[] **sections** _(Pflicht)_");
+        
+        for (SectionConfig section : sections) {
+            visualizeSection(section, indent + "*", writer);
+        }
+    }
+    
+    private void visualizeSection(SectionConfig section, String indent, PrintWriter writer) {
+        String required = section.min() > 0 ? 
+            getSeverityIcon(Severity.ERROR) : getSeverityIcon(Severity.INFO);
+        
+        writer.println(indent + " " + required + " **" + section.name() + "** - " + 
+                      getSectionDescription(section));
+        writer.println(indent + "* Level: " + section.level());
+        
+        if (section.order() != null) {
+            writer.println(indent + "* Position: " + section.order());
+        }
+        
+        if (section.allowedBlocks() != null && !section.allowedBlocks().isEmpty()) {
+            writer.println(indent + "* icon:cubes[] **allowedBlocks**");
+            for (Block block : section.allowedBlocks()) {
+                visualizeBlock(block, indent + "**", writer);
+            }
+        }
+        
+        if (section.subsections() != null && !section.subsections().isEmpty()) {
+            writer.println(indent + "* **subsections**");
+            for (SectionConfig subsection : section.subsections()) {
+                visualizeSection(subsection, indent + "*", writer);
+            }
+        }
+    }
+    
+    private void visualizeBlock(Block block, String indent, PrintWriter writer) {
+        String icon = getSeverityIcon(block.getSeverity());
+        String blockIcon = getBlockIcon(block);
+        
+        writer.print(indent + " " + blockIcon + " **" + block.getType().toValue() + "**");
+        if (block.getName() != null) {
+            writer.print(" (" + block.getName() + ")");
+        }
+        
+        if (block.getOccurrence() != null) {
+            writer.print(" (");
+            Integer min = block.getOccurrence().min();
+            Integer max = block.getOccurrence().max();
+            if (min != null && max != null) {
+                writer.print(min + "-" + max + " Stück");
+            } else if (min != null) {
+                writer.print("min. " + min + " Stück");
+            } else if (max != null) {
+                writer.print("max. " + max + " Stück");
+            }
+            writer.print(")");
+        }
+        writer.println();
+        
+        // Add block-specific rules
+        visualizeBlockRules(block, indent + "*", writer);
+    }
+    
+    private void visualizeBlockRules(Block block, String indent, PrintWriter writer) {
+        // TODO: Add specific rules based on block type
+        // For now, just show severity if it differs from default
+        writer.println(indent + " " + getSeverityIcon(block.getSeverity()) + 
+                      " Schweregrad: " + block.getSeverity());
+    }
+    
+    private String getSeverityIcon(Severity severity) {
+        return switch (severity) {
+            case ERROR -> "icon:times-circle[role=\"red\"]";
+            case WARN -> "icon:exclamation-triangle[role=\"yellow\"]";
+            case INFO -> "icon:info-circle[role=\"blue\"]";
+        };
+    }
+    
+    private String getBlockIcon(Block block) {
+        return switch (block.getType()) {
+            case PARAGRAPH -> "icon:paragraph[]";
+            case LISTING -> "icon:code[]";
+            case TABLE -> "icon:table[]";
+            case IMAGE -> "icon:image[]";
+            case VERSE -> "icon:quote-left[]";
+            case ADMONITION -> "icon:exclamation[]";
+            case PASS -> "icon:forward[]";
+            case LITERAL -> "icon:file-code[]";
+            default -> "icon:file[]";
+        };
+    }
+    
+    private String getAttributeDescription(AttributeConfig attr) {
+        return switch (attr.name()) {
+            case "title" -> "Dokumenttitel";
+            case "author" -> "Verfasser";
+            case "version" -> "Versionsnummer";
+            case "email" -> "Kontakt-E-Mail";
+            default -> attr.name();
+        };
+    }
+    
+    private String getSectionDescription(SectionConfig section) {
+        return switch (section.name()) {
+            case "introduction" -> "Einführungsabschnitt";
+            case "implementation" -> "Implementierungsdetails";
+            case "conclusion" -> "Zusammenfassung";
+            default -> section.name();
+        };
+    }
+}

--- a/src/main/java/com/example/linter/documentation/visualizers/TableVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/TableVisualizer.java
@@ -1,0 +1,210 @@
+package com.example.linter.documentation.visualizers;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.example.linter.config.DocumentConfiguration;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.MetadataConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.AttributeConfig;
+import com.example.linter.config.rule.SectionConfig;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.documentation.HierarchyVisualizer;
+import com.example.linter.documentation.VisualizationStyle;
+
+/**
+ * Visualizes rule hierarchy as a table with indentation.
+ */
+public class TableVisualizer implements HierarchyVisualizer {
+    
+    private static final String INDENT = "{nbsp}{nbsp}";
+    
+    private static class TableRow {
+        final String rule;
+        final int level;
+        final Severity severity;
+        final String type;
+        final String requirements;
+        
+        TableRow(String rule, int level, Severity severity, String type, String requirements) {
+            this.rule = rule;
+            this.level = level;
+            this.severity = severity;
+            this.type = type;
+            this.requirements = requirements;
+        }
+    }
+    
+    @Override
+    public void visualize(LinterConfiguration config, PrintWriter writer) {
+        List<TableRow> rows = collectTableRows(config.document());
+        
+        writer.println("[%header,cols=\"<4,^1,^1,2,3\"]");
+        writer.println("|===");
+        writer.println("|Regel |Level |Severity |Typ |Anforderungen");
+        writer.println();
+        
+        for (TableRow row : rows) {
+            writer.println("|" + getIndentedRule(row.rule, row.level));
+            writer.println("|" + row.level);
+            writer.println("|" + (row.severity != null ? row.severity : "—"));
+            writer.println("|" + row.type);
+            writer.println("|" + row.requirements);
+            writer.println();
+        }
+        
+        writer.println("|===");
+        writer.println();
+        writer.println("_* = Überschreibt übergeordnete Severity_");
+    }
+    
+    @Override
+    public VisualizationStyle getStyle() {
+        return VisualizationStyle.TABLE;
+    }
+    
+    private List<TableRow> collectTableRows(DocumentConfiguration doc) {
+        List<TableRow> rows = new ArrayList<>();
+        
+        // Add document root
+        rows.add(new TableRow("**DOKUMENT**", 0, null, "Root", "Basis-Konfiguration"));
+        
+        // Add metadata
+        if (doc.metadata() != null) {
+            collectMetadataRows(doc.metadata(), 1, rows);
+        }
+        
+        // Add sections
+        if (doc.sections() != null && !doc.sections().isEmpty()) {
+            rows.add(new TableRow("└ sections", 1, Severity.ERROR, "Container", "Mind. 1 Section"));
+            
+            for (SectionConfig section : doc.sections()) {
+                collectSectionRows(section, 2, rows);
+            }
+        }
+        
+        return rows;
+    }
+    
+    private void collectMetadataRows(MetadataConfiguration metadata, int level, 
+                                    List<TableRow> rows) {
+        rows.add(new TableRow("└ metadata", level, Severity.ERROR, "Container", "Pflicht"));
+        
+        if (metadata.attributes() != null) {
+            for (int i = 0; i < metadata.attributes().size(); i++) {
+                AttributeConfig attr = metadata.attributes().get(i);
+                boolean isLast = i == metadata.attributes().size() - 1;
+                String prefix = isLast ? "└ " : "├ ";
+                
+                String requirements = buildAttributeRequirements(attr);
+                rows.add(new TableRow(prefix + attr.name(), level + 1, attr.severity(), 
+                                     "Attribut", requirements));
+            }
+        }
+    }
+    
+    private void collectSectionRows(SectionConfig section, int level, 
+                                   List<TableRow> rows) {
+        String requirements = "Level " + section.level();
+        if (section.order() != null) {
+            requirements += ", Position " + section.order();
+        }
+        
+        Severity severity = section.min() > 0 ? 
+                          Severity.ERROR : Severity.INFO;
+        
+        rows.add(new TableRow("└ " + section.name(), level, severity, "Section", requirements));
+        
+        if (section.allowedBlocks() != null && !section.allowedBlocks().isEmpty()) {
+            rows.add(new TableRow("├ allowedBlocks", level + 1, null, "Container", 
+                                 "Block-Definitionen"));
+            
+            for (int i = 0; i < section.allowedBlocks().size(); i++) {
+                Block block = section.allowedBlocks().get(i);
+                boolean isLast = i == section.allowedBlocks().size() - 1;
+                
+                collectBlockRows(block, level + 2, isLast, rows);
+            }
+        }
+        
+        if (section.subsections() != null && !section.subsections().isEmpty()) {
+            rows.add(new TableRow("└ subsections", level + 1, null, "Container", 
+                                 "Unterabschnitte"));
+            
+            for (SectionConfig subsection : section.subsections()) {
+                collectSectionRows(subsection, level + 2, rows);
+            }
+        }
+    }
+    
+    private void collectBlockRows(Block block, int level, boolean isLast, 
+                                 List<TableRow> rows) {
+        String prefix = isLast ? "└ " : "├ ";
+        String requirements = getBlockDescription(block);
+        
+        rows.add(new TableRow(prefix + block.getType().toValue(), level, 
+                             block.getSeverity(), "Block", requirements));
+        
+        // Add block-specific rules
+        // TODO: Add specific rules based on block type with severity override indicators
+    }
+    
+    private String getIndentedRule(String rule, int level) {
+        StringBuilder indented = new StringBuilder();
+        for (int i = 0; i < level; i++) {
+            indented.append(INDENT);
+        }
+        indented.append(rule);
+        return indented.toString();
+    }
+    
+    private String buildAttributeRequirements(AttributeConfig attr) {
+        List<String> reqs = new ArrayList<>();
+        
+        if (attr.required()) {
+            reqs.add("Pflicht");
+        } else {
+            reqs.add("Optional");
+        }
+        
+        if (attr.minLength() != null || attr.maxLength() != null) {
+            if (attr.minLength() != null && attr.maxLength() != null) {
+                reqs.add(attr.minLength() + "-" + attr.maxLength() + " Zeichen");
+            } else if (attr.minLength() != null) {
+                reqs.add("Min. " + attr.minLength() + " Zeichen");
+            } else {
+                reqs.add("Max. " + attr.maxLength() + " Zeichen");
+            }
+        }
+        
+        if (attr.pattern() != null) {
+            reqs.add("Muster definiert");
+        }
+        
+        return String.join(", ", reqs);
+    }
+    
+    private String getBlockDescription(Block block) {
+        List<String> desc = new ArrayList<>();
+        
+        if (block.getName() != null) {
+            desc.add(block.getName());
+        }
+        
+        if (block.getOccurrence() != null) {
+            Integer min = block.getOccurrence().min();
+            Integer max = block.getOccurrence().max();
+            if (min != null && max != null) {
+                desc.add(min + "-" + max + " mal");
+            } else if (min != null) {
+                desc.add("Min. " + min + " mal");
+            } else if (max != null) {
+                desc.add("Max. " + max + " mal");
+            }
+        }
+        
+        return desc.isEmpty() ? "Keine speziellen Anforderungen" : String.join(", ", desc);
+    }
+}

--- a/src/main/java/com/example/linter/documentation/visualizers/TreeVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/TreeVisualizer.java
@@ -1,0 +1,167 @@
+package com.example.linter.documentation.visualizers;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+import com.example.linter.config.DocumentConfiguration;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.MetadataConfiguration;
+import com.example.linter.config.rule.AttributeConfig;
+import com.example.linter.config.rule.SectionConfig;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.documentation.HierarchyVisualizer;
+import com.example.linter.documentation.VisualizationStyle;
+
+/**
+ * Visualizes rule hierarchy as an ASCII-art tree structure.
+ */
+public class TreeVisualizer implements HierarchyVisualizer {
+    
+    private static final String VERTICAL = "│   ";
+    private static final String BRANCH = "├── ";
+    private static final String LAST_BRANCH = "└── ";
+    private static final String EMPTY = "    ";
+    
+    @Override
+    public void visualize(LinterConfiguration config, PrintWriter writer) {
+        writer.println("[literal]");
+        writer.println("....");
+        visualizeDocument(config.document(), "", writer);
+        writer.println("....");
+    }
+    
+    @Override
+    public VisualizationStyle getStyle() {
+        return VisualizationStyle.TREE;
+    }
+    
+    private void visualizeDocument(DocumentConfiguration doc, String prefix, PrintWriter writer) {
+        writer.println(prefix + "document/");
+        
+        boolean hasMetadata = doc.metadata() != null;
+        boolean hasSections = doc.sections() != null && !doc.sections().isEmpty();
+        
+        if (hasMetadata) {
+            String childPrefix = prefix + (hasSections ? VERTICAL : EMPTY);
+            visualizeMetadata(doc.metadata(), prefix + BRANCH, childPrefix, writer);
+        }
+        
+        if (hasSections) {
+            visualizeSections(doc.sections(), prefix + LAST_BRANCH, prefix + EMPTY, writer);
+        }
+    }
+    
+    private void visualizeMetadata(MetadataConfiguration metadata, String nodePrefix, 
+                                  String childPrefix, PrintWriter writer) {
+        writer.println(nodePrefix + "metadata/");
+        
+        if (metadata.attributes() != null && !metadata.attributes().isEmpty()) {
+            List<AttributeConfig> attrs = metadata.attributes();
+            for (int i = 0; i < attrs.size(); i++) {
+                AttributeConfig attr = attrs.get(i);
+                boolean isLast = i == attrs.size() - 1;
+                String branch = isLast ? LAST_BRANCH : BRANCH;
+                
+                String attrLine = childPrefix + branch + attr.name();
+                if (attr.required()) {
+                    attrLine += " (required)";
+                } else {
+                    attrLine += " (optional)";
+                }
+                attrLine += " [" + attr.severity() + "]";
+                
+                writer.println(attrLine);
+            }
+        }
+    }
+    
+    private void visualizeSections(List<SectionConfig> sections, String nodePrefix, 
+                                  String childPrefix, PrintWriter writer) {
+        writer.println(nodePrefix + "sections/");
+        
+        for (int i = 0; i < sections.size(); i++) {
+            SectionConfig section = sections.get(i);
+            boolean isLast = i == sections.size() - 1;
+            String branch = isLast ? LAST_BRANCH : BRANCH;
+            String nextChildPrefix = childPrefix + (isLast ? EMPTY : VERTICAL);
+            
+            visualizeSection(section, childPrefix + branch, nextChildPrefix, writer);
+        }
+    }
+    
+    private void visualizeSection(SectionConfig section, String nodePrefix, 
+                                 String childPrefix, PrintWriter writer) {
+        String sectionLine = nodePrefix + section.name() + "/";
+        sectionLine += " [Level " + section.level();
+        if (section.order() != null) {
+            sectionLine += ", Order " + section.order();
+        }
+        sectionLine += "]";
+        writer.println(sectionLine);
+        
+        boolean hasBlocks = section.allowedBlocks() != null && !section.allowedBlocks().isEmpty();
+        boolean hasSubsections = section.subsections() != null && !section.subsections().isEmpty();
+        
+        if (hasBlocks) {
+            String blocksPrefix = hasSubsections ? BRANCH : LAST_BRANCH;
+            String nextChildPrefix = childPrefix + (hasSubsections ? VERTICAL : EMPTY);
+            visualizeBlocks(section.allowedBlocks(), childPrefix + blocksPrefix, 
+                          nextChildPrefix, writer);
+        }
+        
+        if (hasSubsections) {
+            visualizeSections(section.subsections(), childPrefix + LAST_BRANCH, 
+                            childPrefix + EMPTY, writer);
+        }
+    }
+    
+    private void visualizeBlocks(List<Block> blocks, String nodePrefix, 
+                               String childPrefix, PrintWriter writer) {
+        writer.println(nodePrefix + "allowedBlocks/");
+        
+        for (int i = 0; i < blocks.size(); i++) {
+            Block block = blocks.get(i);
+            boolean isLast = i == blocks.size() - 1;
+            String branch = isLast ? LAST_BRANCH : BRANCH;
+            String nextChildPrefix = childPrefix + (isLast ? EMPTY : VERTICAL);
+            
+            visualizeBlock(block, childPrefix + branch, nextChildPrefix, writer);
+        }
+    }
+    
+    private void visualizeBlock(Block block, String nodePrefix, String childPrefix, 
+                               PrintWriter writer) {
+        String blockLine = nodePrefix + block.getType().toValue() + "/";
+        if (block.getName() != null) {
+            blockLine += " (" + block.getName() + ")";
+        }
+        blockLine += " [" + block.getSeverity() + "]";
+        writer.println(blockLine);
+        
+        // Add block-specific details
+        visualizeBlockDetails(block, childPrefix, writer);
+    }
+    
+    private void visualizeBlockDetails(Block block, String prefix, PrintWriter writer) {
+        // TODO: Add specific details based on block type
+        // For example, for AudioBlock show url, options, title requirements
+        if (block.getOccurrence() != null) {
+            String occurrenceLine = prefix + LAST_BRANCH + "occurrence: ";
+            Integer min = block.getOccurrence().min();
+            Integer max = block.getOccurrence().max();
+            if (min != null) {
+                occurrenceLine += "min " + min;
+            }
+            if (max != null) {
+                if (min != null) {
+                    occurrenceLine += ", ";
+                }
+                occurrenceLine += "max " + max;
+            }
+            if (block.getOccurrence().severity() != null) {
+                occurrenceLine += " [" + block.getOccurrence().severity() + "]";
+            }
+            writer.println(occurrenceLine);
+        }
+    }
+}

--- a/src/test/java/com/example/linter/cli/CLIOptionsTest.java
+++ b/src/test/java/com/example/linter/cli/CLIOptionsTest.java
@@ -61,14 +61,18 @@ class CLIOptionsTest {
     }
     
     @Test
-    @DisplayName("should require input parameter")
-    void shouldRequireInputParameter() {
+    @DisplayName("should parse without input when using generate-docs")
+    void shouldParseWithoutInputWhenUsingGenerateDocs() throws ParseException {
         // Given
-        String[] args = {"-c", "config.yaml"};
+        String[] args = {"--generate-docs", "-c", "config.yaml"};
         
-        // When/Then
-        assertThrows(ParseException.class, () -> 
-            parser.parse(cliOptions.getOptions(), args));
+        // When
+        CommandLine cmd = parser.parse(cliOptions.getOptions(), args);
+        
+        // Then
+        assertTrue(cmd.hasOption("generate-docs"));
+        assertTrue(cmd.hasOption("config"));
+        assertFalse(cmd.hasOption("input"));
     }
     
     @Test

--- a/src/test/java/com/example/linter/documentation/AsciiDocRuleGeneratorTest.java
+++ b/src/test/java/com/example/linter/documentation/AsciiDocRuleGeneratorTest.java
@@ -1,0 +1,252 @@
+package com.example.linter.documentation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.DocumentConfiguration;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.MetadataConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.AttributeConfig;
+import com.example.linter.config.rule.SectionConfig;
+import com.example.linter.config.rule.OccurrenceConfig;
+import com.example.linter.config.blocks.ParagraphBlock;
+
+@DisplayName("AsciiDocRuleGenerator")
+class AsciiDocRuleGeneratorTest {
+    
+    private AsciiDocRuleGenerator generator;
+    private StringWriter stringWriter;
+    private PrintWriter printWriter;
+    
+    @BeforeEach
+    void setUp() {
+        generator = new AsciiDocRuleGenerator();
+        stringWriter = new StringWriter();
+        printWriter = new PrintWriter(stringWriter);
+    }
+    
+    @Test
+    @DisplayName("should return correct format")
+    void shouldReturnCorrectFormat() {
+        assertEquals(DocumentationFormat.ASCIIDOC, generator.getFormat());
+    }
+    
+    @Test
+    @DisplayName("should return correct name")
+    void shouldReturnCorrectName() {
+        assertEquals("AsciiDoc Rule Documentation Generator", generator.getName());
+    }
+    
+    @Nested
+    @DisplayName("Generate Documentation")
+    class GenerateDocumentation {
+        
+        @Test
+        @DisplayName("should require non-null configuration")
+        void shouldRequireNonNullConfiguration() {
+            assertThrows(NullPointerException.class, () -> 
+                generator.generate(null, printWriter)
+            );
+        }
+        
+        @Test
+        @DisplayName("should require non-null writer")
+        void shouldRequireNonNullWriter() {
+            LinterConfiguration config = LinterConfiguration.builder()
+                .document(DocumentConfiguration.builder().build())
+                .build();
+            
+            assertThrows(NullPointerException.class, () -> 
+                generator.generate(config, null)
+            );
+        }
+        
+        @Test
+        @DisplayName("should generate basic documentation structure")
+        void shouldGenerateBasicDocumentationStructure() {
+            // Given
+            LinterConfiguration config = LinterConfiguration.builder()
+                .document(DocumentConfiguration.builder().build())
+                .build();
+            
+            // When
+            generator.generate(config, printWriter);
+            printWriter.flush();
+            String output = stringWriter.toString();
+            
+            // Then
+            assertTrue(output.contains("= AsciiDoc Dokument-Richtlinien"));
+            assertTrue(output.contains(":toc: left"));
+            assertTrue(output.contains("== Einführung"));
+            assertTrue(output.contains("== Validierungsstufen"));
+            assertTrue(output.contains("== Tipps für Autoren"));
+        }
+        
+        @Test
+        @DisplayName("should generate metadata documentation")
+        void shouldGenerateMetadataDocumentation() {
+            // Given
+            AttributeConfig titleAttr = AttributeConfig.builder()
+                .name("title")
+                .required(true)
+                .minLength(10)
+                .maxLength(100)
+                .severity(Severity.ERROR)
+                .build();
+            
+            AttributeConfig authorAttr = AttributeConfig.builder()
+                .name("author")
+                .required(false)
+                .pattern("^[A-Z].*")
+                .severity(Severity.WARN)
+                .build();
+            
+            MetadataConfiguration metadata = MetadataConfiguration.builder()
+                .attributes(List.of(titleAttr, authorAttr))
+                .build();
+            
+            DocumentConfiguration document = DocumentConfiguration.builder()
+                .metadata(metadata)
+                .build();
+            
+            LinterConfiguration config = LinterConfiguration.builder()
+                .document(document)
+                .build();
+            
+            // When
+            generator.generate(config, printWriter);
+            printWriter.flush();
+            String output = stringWriter.toString();
+            
+            // Then
+            assertTrue(output.contains("== Dokument-Metadaten"));
+            assertTrue(output.contains("=== Pflichtattribute"));
+            assertTrue(output.contains("=== Optionale Attribute"));
+            assertTrue(output.contains("|title"));
+            assertTrue(output.contains("|author"));
+            assertTrue(output.contains("Mindestlänge: 10 Zeichen"));
+            assertTrue(output.contains("Maximallänge: 100 Zeichen"));
+        }
+        
+        @Test
+        @DisplayName("should generate section documentation")
+        void shouldGenerateSectionDocumentation() {
+            // Given
+            ParagraphBlock paragraph = ParagraphBlock.builder()
+                .severity(Severity.WARN)
+                .occurrence(OccurrenceConfig.builder()
+                    .min(1)
+                    .max(3)
+                    .build())
+                .build();
+            
+            SectionConfig section = SectionConfig.builder()
+                .name("introduction")
+                .level(1)
+                .order(1)
+                .min(1)
+                .max(1)
+                .allowedBlocks(List.of(paragraph))
+                .build();
+            
+            DocumentConfiguration document = DocumentConfiguration.builder()
+                .sections(List.of(section))
+                .build();
+            
+            LinterConfiguration config = LinterConfiguration.builder()
+                .document(document)
+                .build();
+            
+            // When
+            generator.generate(config, printWriter);
+            printWriter.flush();
+            String output = stringWriter.toString();
+            
+            // Then
+            assertTrue(output.contains("== Dokumentstruktur"));
+            assertTrue(output.contains("=== Abschnitt: introduction"));
+            assertTrue(output.contains("**Level**: 1"));
+            assertTrue(output.contains("paragraph"));
+        }
+    }
+    
+    @Nested
+    @DisplayName("Visualization Styles")
+    class VisualizationStyles {
+        
+        @Test
+        @DisplayName("should use default tree visualization")
+        void shouldUseDefaultTreeVisualization() {
+            // Given
+            SectionConfig section = SectionConfig.builder()
+                .name("test")
+                .level(1)
+                .build();
+            
+            DocumentConfiguration document = DocumentConfiguration.builder()
+                .sections(List.of(section))
+                .build();
+            
+            LinterConfiguration config = LinterConfiguration.builder()
+                .document(document)
+                .build();
+            
+            // When
+            generator.generate(config, printWriter);
+            printWriter.flush();
+            String output = stringWriter.toString();
+            
+            // Then
+            assertTrue(output.contains("[literal]"));
+            assertTrue(output.contains("document/"));
+        }
+        
+        @Test
+        @DisplayName("should support multiple visualization styles")
+        void shouldSupportMultipleVisualizationStyles() {
+            // Given
+            AsciiDocRuleGenerator multiStyleGenerator = new AsciiDocRuleGenerator(
+                Set.of(VisualizationStyle.TREE, VisualizationStyle.TABLE)
+            );
+            
+            SectionConfig section = SectionConfig.builder()
+                .name("test")
+                .level(1)
+                .build();
+            
+            DocumentConfiguration document = DocumentConfiguration.builder()
+                .sections(List.of(section))
+                .build();
+            
+            LinterConfiguration config = LinterConfiguration.builder()
+                .document(document)
+                .build();
+            
+            // When
+            assertDoesNotThrow(() -> {
+                multiStyleGenerator.generate(config, printWriter);
+                printWriter.flush();
+            });
+            
+            String output = stringWriter.toString();
+            
+            // Then
+            assertTrue(output.contains("ASCII-art tree structure"));
+            assertTrue(output.contains("Hierarchical table with indentation"));
+        }
+    }
+}

--- a/src/test/java/com/example/linter/documentation/PatternHumanizerTest.java
+++ b/src/test/java/com/example/linter/documentation/PatternHumanizerTest.java
@@ -1,0 +1,148 @@
+package com.example.linter.documentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PatternHumanizer")
+class PatternHumanizerTest {
+    
+    private PatternHumanizer humanizer;
+    
+    @BeforeEach
+    void setUp() {
+        humanizer = new PatternHumanizer();
+    }
+    
+    @Nested
+    @DisplayName("Known Patterns")
+    class KnownPatterns {
+        
+        @Test
+        @DisplayName("should humanize uppercase start pattern")
+        void shouldHumanizeUppercaseStartPattern() {
+            String result = humanizer.humanize("^[A-Z].*");
+            assertEquals("Muss mit einem Großbuchstaben beginnen", result);
+        }
+        
+        @Test
+        @DisplayName("should humanize semantic versioning pattern")
+        void shouldHumanizeSemanticVersioningPattern() {
+            String result = humanizer.humanize("^\\d+\\.\\d+\\.\\d+$");
+            assertEquals("Semantic Versioning Format (z.B. 1.0.0)", result);
+        }
+        
+        @Test
+        @DisplayName("should humanize email pattern")
+        void shouldHumanizeEmailPattern() {
+            String result = humanizer.humanize("^[\\w._%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$");
+            assertEquals("Gültige E-Mail-Adresse", result);
+        }
+        
+        @Test
+        @DisplayName("should humanize image file pattern")
+        void shouldHumanizeImageFilePattern() {
+            String result = humanizer.humanize(".*\\.(png|jpg|jpeg|gif|svg)$");
+            assertEquals("Bilddatei (PNG, JPG, JPEG, GIF oder SVG)", result);
+        }
+        
+        @Test
+        @DisplayName("should humanize audio file pattern")
+        void shouldHumanizeAudioFilePattern() {
+            String result = humanizer.humanize(".*\\.(mp3|ogg|wav|m4a)$");
+            assertEquals("Audiodatei (MP3, OGG, WAV oder M4A)", result);
+        }
+    }
+    
+    @Nested
+    @DisplayName("Generated Descriptions")
+    class GeneratedDescriptions {
+        
+        @Test
+        @DisplayName("should generate description for simple starts-with pattern")
+        void shouldGenerateStartsWithDescription() {
+            String result = humanizer.humanize("^Chapter");
+            assertEquals("Muss mit 'Chapter' beginnen", result);
+        }
+        
+        @Test
+        @DisplayName("should generate description for simple ends-with pattern")
+        void shouldGenerateEndsWithDescription() {
+            String result = humanizer.humanize("END$");
+            assertEquals("Muss mit 'END' enden", result);
+        }
+        
+        @Test
+        @DisplayName("should generate description for exact match pattern")
+        void shouldGenerateExactMatchDescription() {
+            String result = humanizer.humanize("^EXACT$");
+            assertEquals("Muss genau 'EXACT' sein", result);
+        }
+        
+        @Test
+        @DisplayName("should generate description for letters only pattern")
+        void shouldGenerateLettersOnlyDescription() {
+            String result = humanizer.humanize("^[A-Za-z]+$");
+            assertEquals("Nur Buchstaben erlaubt", result);
+        }
+        
+        @Test
+        @DisplayName("should generate description for numbers only pattern")
+        void shouldGenerateNumbersOnlyDescription() {
+            String result = humanizer.humanize("^[0-9]+$");
+            assertEquals("Nur Zahlen erlaubt", result);
+        }
+    }
+    
+    @Nested
+    @DisplayName("Edge Cases")
+    class EdgeCases {
+        
+        @Test
+        @DisplayName("should handle null pattern")
+        void shouldHandleNullPattern() {
+            String result = humanizer.humanize((Pattern) null);
+            assertEquals("", result);
+        }
+        
+        @Test
+        @DisplayName("should handle empty pattern string")
+        void shouldHandleEmptyPatternString() {
+            String result = humanizer.humanize("");
+            assertEquals("", result);
+        }
+        
+        @Test
+        @DisplayName("should show pattern for complex regex")
+        void shouldShowPatternForComplexRegex() {
+            String complex = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z]).{8,}$";
+            String result = humanizer.humanize(complex);
+            assertEquals("Muss dem Muster entsprechen: " + complex, result);
+        }
+    }
+    
+    @Nested
+    @DisplayName("Custom Patterns")
+    class CustomPatterns {
+        
+        @Test
+        @DisplayName("should use registered custom pattern")
+        void shouldUseRegisteredCustomPattern() {
+            // Given
+            String pattern = "^CUSTOM-\\d{4}$";
+            String description = "Muss dem Format CUSTOM-XXXX entsprechen (4 Ziffern)";
+            
+            // When
+            humanizer.registerPattern(pattern, description);
+            String result = humanizer.humanize(pattern);
+            
+            // Then
+            assertEquals(description, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements a Rule Documentation Generator that converts YAML linter rules into human-readable AsciiDoc documentation for content authors.

## Changes
- Add `RuleDocumentationGenerator` interface for extensible documentation generation
- Implement `AsciiDocRuleGenerator` with human-readable output in German
- Create multiple visualization strategies: tree, nested, breadcrumb, table
- Add `PatternHumanizer` to convert regex patterns to readable descriptions
- Integrate documentation generation into CLI with `--generate-docs` option
- Support multiple visualization styles via `--viz-style` parameter

## Test plan
- [x] Unit tests for AsciiDocRuleGenerator
- [x] Unit tests for PatternHumanizer
- [x] Manual CLI testing with test configuration
- [x] Verify generated AsciiDoc output
- [ ] Add tests for visualizer implementations
- [ ] Add tests for factory and enums

## Known Issues
The implementation deviates from some established patterns:
- Missing Builder pattern for immutability
- Test coverage only ~28% (missing tests for visualizers)
- No custom DocumentationException
- Factory pattern differs from ReportWriter approach

These should be addressed in a follow-up PR to maintain code consistency.

Closes #50