### PR TITLE
#56 Add EXAMPLE block type support

### DIFF
--- a/docs/linter-config-specification.yaml
+++ b/docs/linter-config-specification.yaml
@@ -672,3 +672,21 @@ document:
                 min: 1
                 max: 20
                 severity: info
+        - example:
+            name: "code-example"             # Für Beispielblöcke mit optionaler Nummerierung
+            severity: warn                   # PFLICHT: Default-Severity für den gesamten Block
+            occurrence:
+              min: 0
+              max: 10
+              # Kein severity = verwendet Block-Severity (warn)
+            # Example-spezifische Attribute
+            caption:
+              required: true                 # Caption ist Pflicht
+              pattern: "^(Example|Beispiel)\\s+\\d+\\.\\d*:.*"  # Format: "Example 1.2: Beschreibung"
+              minLength: 15
+              maxLength: 100
+              severity: error
+            collapsible:
+              required: false                # Klappbar machen optional
+              allowed: [true, false]
+              severity: info

--- a/src/main/java/com/example/linter/config/BlockType.java
+++ b/src/main/java/com/example/linter/config/BlockType.java
@@ -13,7 +13,8 @@ public enum BlockType {
     PASS,
     LITERAL,
     AUDIO,
-    QUOTE;
+    QUOTE,
+    EXAMPLE;
     
     @JsonValue
     public String toValue() {
@@ -34,6 +35,7 @@ public enum BlockType {
             case "literal" -> LITERAL;
             case "audio" -> AUDIO;
             case "quote" -> QUOTE;
+            case "example" -> EXAMPLE;
             default -> throw new IllegalArgumentException("Unknown block type: " + value);
         };
     }

--- a/src/main/java/com/example/linter/config/blocks/ExampleBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/ExampleBlock.java
@@ -1,0 +1,302 @@
+package com.example.linter.config.blocks;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+/**
+ * Configuration for EXAMPLE blocks.
+ * 
+ * Validates example blocks with optional numbering and caption format.
+ * Based on the YAML schema definition for the linter.
+ */
+@JsonDeserialize(builder = ExampleBlock.Builder.class)
+public class ExampleBlock extends AbstractBlock {
+    
+    private final CaptionConfig caption;
+    private final CollapsibleConfig collapsible;
+    
+    private ExampleBlock(Builder builder) {
+        super(builder);
+        this.caption = builder.caption;
+        this.collapsible = builder.collapsible;
+    }
+    
+    @Override
+    public BlockType getType() {
+        return BlockType.EXAMPLE;
+    }
+    
+    public CaptionConfig getCaption() {
+        return caption;
+    }
+    
+    public CollapsibleConfig getCollapsible() {
+        return collapsible;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ExampleBlock that = (ExampleBlock) o;
+        return Objects.equals(caption, that.caption) &&
+               Objects.equals(collapsible, that.collapsible);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), caption, collapsible);
+    }
+    
+    @Override
+    public String toString() {
+        return "ExampleBlock{" +
+                "name='" + getName() + '\'' +
+                ", severity=" + getSeverity() +
+                ", occurrence=" + getOccurrence() +
+                ", caption=" + caption +
+                ", collapsible=" + collapsible +
+                '}';
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class Builder extends AbstractBlock.AbstractBuilder<Builder> {
+        private CaptionConfig caption;
+        private CollapsibleConfig collapsible;
+        
+        @JsonProperty("caption")
+        public Builder caption(CaptionConfig caption) {
+            this.caption = caption;
+            return this;
+        }
+        
+        @JsonProperty("collapsible")
+        public Builder collapsible(CollapsibleConfig collapsible) {
+            this.collapsible = collapsible;
+            return this;
+        }
+        
+        @Override
+        public ExampleBlock build() {
+            return new ExampleBlock(this);
+        }
+    }
+    
+    /**
+     * Configuration for the caption of an example block.
+     * Based on the YAML schema requiring specific format.
+     */
+    @JsonDeserialize(builder = CaptionConfig.Builder.class)
+    public static class CaptionConfig {
+        private final boolean required;
+        private final Pattern pattern;
+        private final Integer minLength;
+        private final Integer maxLength;
+        private final Severity severity;
+        
+        private CaptionConfig(Builder builder) {
+            this.required = builder.required;
+            this.pattern = builder.pattern;
+            this.minLength = builder.minLength;
+            this.maxLength = builder.maxLength;
+            this.severity = builder.severity;
+        }
+        
+        public boolean isRequired() {
+            return required;
+        }
+        
+        public Pattern getPattern() {
+            return pattern;
+        }
+        
+        public Integer getMinLength() {
+            return minLength;
+        }
+        
+        public Integer getMaxLength() {
+            return maxLength;
+        }
+        
+        public Severity getSeverity() {
+            return severity;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CaptionConfig that = (CaptionConfig) o;
+            return required == that.required &&
+                   Objects.equals(pattern == null ? null : pattern.pattern(), 
+                                that.pattern == null ? null : that.pattern.pattern()) &&
+                   Objects.equals(minLength, that.minLength) &&
+                   Objects.equals(maxLength, that.maxLength) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, 
+                              pattern == null ? null : pattern.pattern(), 
+                              minLength, maxLength, severity);
+        }
+        
+        @Override
+        public String toString() {
+            return "CaptionConfig{" +
+                    "required=" + required +
+                    ", pattern=" + (pattern == null ? null : pattern.pattern()) +
+                    ", minLength=" + minLength +
+                    ", maxLength=" + maxLength +
+                    ", severity=" + severity +
+                    '}';
+        }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private boolean required = false;
+            private Pattern pattern;
+            private Integer minLength;
+            private Integer maxLength;
+            private Severity severity;
+            
+            @JsonProperty("required")
+            public Builder required(boolean required) {
+                this.required = required;
+                return this;
+            }
+            
+            @JsonProperty("pattern")
+            public Builder pattern(String pattern) {
+                this.pattern = pattern != null ? Pattern.compile(pattern) : null;
+                return this;
+            }
+            
+            @JsonProperty("minLength")
+            public Builder minLength(Integer minLength) {
+                this.minLength = minLength;
+                return this;
+            }
+            
+            @JsonProperty("maxLength")
+            public Builder maxLength(Integer maxLength) {
+                this.maxLength = maxLength;
+                return this;
+            }
+            
+            @JsonProperty("severity")
+            public Builder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public CaptionConfig build() {
+                return new CaptionConfig(this);
+            }
+        }
+    }
+    
+    /**
+     * Configuration for the collapsible attribute of an example block.
+     * Based on the YAML schema allowing true/false values.
+     */
+    @JsonDeserialize(builder = CollapsibleConfig.Builder.class)
+    public static class CollapsibleConfig {
+        private final boolean required;
+        private final List<Boolean> allowed;
+        private final Severity severity;
+        
+        private CollapsibleConfig(Builder builder) {
+            this.required = builder.required;
+            this.allowed = builder.allowed;
+            this.severity = builder.severity;
+        }
+        
+        public boolean isRequired() {
+            return required;
+        }
+        
+        public List<Boolean> getAllowed() {
+            return allowed;
+        }
+        
+        public Severity getSeverity() {
+            return severity;
+        }
+        
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CollapsibleConfig that = (CollapsibleConfig) o;
+            return required == that.required &&
+                   Objects.equals(allowed, that.allowed) &&
+                   severity == that.severity;
+        }
+        
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, allowed, severity);
+        }
+        
+        @Override
+        public String toString() {
+            return "CollapsibleConfig{" +
+                    "required=" + required +
+                    ", allowed=" + allowed +
+                    ", severity=" + severity +
+                    '}';
+        }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        @JsonPOJOBuilder(withPrefix = "")
+        public static class Builder {
+            private boolean required = false;
+            private List<Boolean> allowed;
+            private Severity severity;
+            
+            @JsonProperty("required")
+            public Builder required(boolean required) {
+                this.required = required;
+                return this;
+            }
+            
+            @JsonProperty("allowed")
+            public Builder allowed(List<Boolean> allowed) {
+                this.allowed = allowed;
+                return this;
+            }
+            
+            @JsonProperty("severity")
+            public Builder severity(Severity severity) {
+                this.severity = severity;
+                return this;
+            }
+            
+            public CollapsibleConfig build() {
+                return new CollapsibleConfig(this);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/linter/config/loader/BlockListDeserializer.java
+++ b/src/main/java/com/example/linter/config/loader/BlockListDeserializer.java
@@ -8,6 +8,7 @@ import com.example.linter.config.BlockType;
 import com.example.linter.config.blocks.AdmonitionBlock;
 import com.example.linter.config.blocks.AudioBlock;
 import com.example.linter.config.blocks.Block;
+import com.example.linter.config.blocks.ExampleBlock;
 import com.example.linter.config.blocks.ImageBlock;
 import com.example.linter.config.blocks.ListingBlock;
 import com.example.linter.config.blocks.LiteralBlock;
@@ -78,6 +79,7 @@ public class BlockListDeserializer extends JsonDeserializer<List<Block>> {
                 case LITERAL -> mapper.treeToValue(blockData, LiteralBlock.class);
                 case AUDIO -> mapper.treeToValue(blockData, AudioBlock.class);
                 case QUOTE -> mapper.treeToValue(blockData, QuoteBlock.class);
+                case EXAMPLE -> mapper.treeToValue(blockData, ExampleBlock.class);
             };
             
             blocks.add(block);

--- a/src/main/java/com/example/linter/validator/block/BlockValidatorFactory.java
+++ b/src/main/java/com/example/linter/validator/block/BlockValidatorFactory.java
@@ -54,6 +54,7 @@ public final class BlockValidatorFactory {
         registerValidator(map, new LiteralBlockValidator());
         registerValidator(map, new AudioBlockValidator());
         registerValidator(map, new QuoteBlockValidator());
+        registerValidator(map, new ExampleBlockValidator());
         
         return map;
     }

--- a/src/main/java/com/example/linter/validator/block/ExampleBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/ExampleBlockValidator.java
@@ -1,0 +1,168 @@
+package com.example.linter.validator.block;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.asciidoctor.ast.StructuralNode;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.config.blocks.ExampleBlock;
+import com.example.linter.validator.ValidationMessage;
+import com.example.linter.validator.SourceLocation;
+
+/**
+ * Validator for EXAMPLE blocks.
+ * 
+ * Validates example blocks according to the YAML schema definition,
+ * including caption format and collapsible attribute.
+ */
+public class ExampleBlockValidator implements BlockTypeValidator {
+    
+    @Override
+    public BlockType getSupportedType() {
+        return BlockType.EXAMPLE;
+    }
+    
+    @Override
+    public List<ValidationMessage> validate(StructuralNode node, Block blockConfig, BlockValidationContext context) {
+        if (!(blockConfig instanceof ExampleBlock exampleBlock)) {
+            throw new IllegalArgumentException("Invalid block config type: " + blockConfig.getClass());
+        }
+        
+        List<ValidationMessage> messages = new ArrayList<>();
+        
+        // Validate caption
+        if (exampleBlock.getCaption() != null) {
+            messages.addAll(validateCaption(node, exampleBlock, context));
+        }
+        
+        // Validate collapsible
+        if (exampleBlock.getCollapsible() != null) {
+            messages.addAll(validateCollapsible(node, exampleBlock, context));
+        }
+        
+        return messages;
+    }
+    
+    private List<ValidationMessage> validateCaption(StructuralNode node, ExampleBlock block, BlockValidationContext context) {
+        List<ValidationMessage> messages = new ArrayList<>();
+        ExampleBlock.CaptionConfig config = block.getCaption();
+        
+        String caption = node.getTitle();
+        
+        // Check if caption is required
+        if (config.isRequired() && (caption == null || caption.trim().isEmpty())) {
+            messages.add(createMessage(
+                "Example block requires a caption",
+                determineSeverity(config.getSeverity(), block.getSeverity()),
+                context.createLocation(node)
+            ));
+            return messages;
+        }
+        
+        // If caption is not present and not required, skip further validation
+        if (caption == null || caption.trim().isEmpty()) {
+            return messages;
+        }
+        
+        // Validate caption length
+        if (config.getMinLength() != null && caption.length() < config.getMinLength()) {
+            messages.add(createMessage(
+                String.format("Example caption length %d is less than required minimum %d",
+                    caption.length(), config.getMinLength()),
+                determineSeverity(config.getSeverity(), block.getSeverity()),
+                context.createLocation(node)
+            ));
+        }
+        
+        if (config.getMaxLength() != null && caption.length() > config.getMaxLength()) {
+            messages.add(createMessage(
+                String.format("Example caption length %d exceeds maximum %d",
+                    caption.length(), config.getMaxLength()),
+                determineSeverity(config.getSeverity(), block.getSeverity()),
+                context.createLocation(node)
+            ));
+        }
+        
+        // Validate caption pattern
+        if (config.getPattern() != null && !config.getPattern().matcher(caption).matches()) {
+            messages.add(createMessage(
+                String.format("Example caption '%s' does not match required pattern '%s'",
+                    caption, config.getPattern().pattern()),
+                determineSeverity(config.getSeverity(), block.getSeverity()),
+                context.createLocation(node)
+            ));
+        }
+        
+        return messages;
+    }
+    
+    private List<ValidationMessage> validateCollapsible(StructuralNode node, ExampleBlock block, BlockValidationContext context) {
+        List<ValidationMessage> messages = new ArrayList<>();
+        ExampleBlock.CollapsibleConfig config = block.getCollapsible();
+        
+        // Check for collapsible attribute
+        Object collapsibleAttr = node.getAttribute("collapsible-option");
+        if (collapsibleAttr == null) {
+            collapsibleAttr = node.getAttribute("collapsible");
+        }
+        
+        // Check if collapsible is required
+        if (config.isRequired() && collapsibleAttr == null) {
+            messages.add(createMessage(
+                "Example block requires a collapsible attribute",
+                determineSeverity(config.getSeverity(), block.getSeverity()),
+                context.createLocation(node)
+            ));
+            return messages;
+        }
+        
+        // If collapsible is not present and not required, skip further validation
+        if (collapsibleAttr == null) {
+            return messages;
+        }
+        
+        // Parse boolean value
+        Boolean collapsibleValue = null;
+        if (collapsibleAttr instanceof Boolean) {
+            collapsibleValue = (Boolean) collapsibleAttr;
+        } else if (collapsibleAttr instanceof String) {
+            String strValue = ((String) collapsibleAttr).toLowerCase();
+            if ("true".equals(strValue) || "yes".equals(strValue) || "1".equals(strValue)) {
+                collapsibleValue = true;
+            } else if ("false".equals(strValue) || "no".equals(strValue) || "0".equals(strValue)) {
+                collapsibleValue = false;
+            }
+        }
+        
+        // Validate allowed values
+        if (config.getAllowed() != null && !config.getAllowed().isEmpty()) {
+            if (collapsibleValue == null || !config.getAllowed().contains(collapsibleValue)) {
+                messages.add(createMessage(
+                    String.format("Example collapsible value '%s' is not in allowed values %s",
+                        collapsibleAttr, config.getAllowed()),
+                    determineSeverity(config.getSeverity(), block.getSeverity()),
+                    context.createLocation(node)
+                ));
+            }
+        }
+        
+        return messages;
+    }
+    
+    private ValidationMessage createMessage(String message, Severity severity, SourceLocation location) {
+        return ValidationMessage.builder()
+                .message(message)
+                .severity(severity)
+                .location(location)
+                .ruleId("example-block")
+                .build();
+    }
+    
+    private Severity determineSeverity(Severity specificSeverity, Severity blockSeverity) {
+        return specificSeverity != null ? specificSeverity : blockSeverity;
+    }
+}

--- a/src/main/resources/schemas/blocks/example-block-schema.yaml
+++ b/src/main/resources/schemas/blocks/example-block-schema.yaml
@@ -1,0 +1,65 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://github.com/basmussen/power-adoc-linter/schemas/blocks/example-block-schema.yaml
+title: Example Block Configuration Schema
+description: Schema for configuring validation rules for AsciiDoc example blocks
+type: object
+properties:
+  name:
+    type: string
+    description: Name identifier for this block configuration
+    minLength: 1
+  severity:
+    $ref: "../common/severity-schema.yaml"
+    description: Default severity level for all validations in this block
+  occurrence:
+    $ref: "../common/occurrence-schema.yaml"
+    description: Rules for how often this block type should appear
+  caption:
+    type: object
+    description: Configuration for the example caption
+    properties:
+      required:
+        type: boolean
+        description: Whether a caption is required
+        default: false
+      pattern:
+        type: string
+        description: Regular expression pattern the caption must match
+        examples:
+          - "^(Example|Beispiel)\\s+\\d+\\.\\d*:.*"
+      minLength:
+        type: integer
+        description: Minimum length for the caption
+        minimum: 0
+      maxLength:
+        type: integer
+        description: Maximum length for the caption
+        minimum: 0
+      severity:
+        $ref: "../common/severity-schema.yaml"
+        description: Severity level for caption validation errors (overrides block severity)
+    additionalProperties: false
+  collapsible:
+    type: object
+    description: Configuration for the collapsible attribute
+    properties:
+      required:
+        type: boolean
+        description: Whether the collapsible attribute is required
+        default: false
+      allowed:
+        type: array
+        description: Allowed values for the collapsible attribute
+        items:
+          type: boolean
+        uniqueItems: true
+        examples:
+          - [true, false]
+      severity:
+        $ref: "../common/severity-schema.yaml"
+        description: Severity level for collapsible validation errors (overrides block severity)
+    additionalProperties: false
+required:
+  - name
+  - severity
+additionalProperties: false

--- a/src/test/java/com/example/linter/config/blocks/ExampleBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/ExampleBlockTest.java
@@ -1,0 +1,308 @@
+package com.example.linter.config.blocks;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.Severity;
+
+@DisplayName("ExampleBlock")
+class ExampleBlockTest {
+    
+    @Nested
+    @DisplayName("Builder")
+    class BuilderTest {
+        
+        @Test
+        @DisplayName("should build with minimal configuration")
+        void shouldBuildWithMinimalConfiguration() {
+            // Given/When
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("example-1")
+                    .severity(Severity.WARN)
+                    .build();
+            
+            // Then
+            assertNotNull(block);
+            assertEquals("example-1", block.getName());
+            assertEquals(Severity.WARN, block.getSeverity());
+            assertNull(block.getCaption());
+            assertNull(block.getCollapsible());
+        }
+        
+        @Test
+        @DisplayName("should build with full configuration")
+        void shouldBuildWithFullConfiguration() {
+            // Given
+            ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder()
+                    .required(true)
+                    .pattern("^Example \\d+:.*")
+                    .minLength(10)
+                    .maxLength(100)
+                    .severity(Severity.ERROR)
+                    .build();
+                    
+            ExampleBlock.CollapsibleConfig collapsible = ExampleBlock.CollapsibleConfig.builder()
+                    .required(false)
+                    .allowed(Arrays.asList(true, false))
+                    .severity(Severity.INFO)
+                    .build();
+            
+            // When
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("example-full")
+                    .severity(Severity.WARN)
+                    .caption(caption)
+                    .collapsible(collapsible)
+                    .build();
+            
+            // Then
+            assertNotNull(block);
+            assertEquals("example-full", block.getName());
+            assertEquals(Severity.WARN, block.getSeverity());
+            assertNotNull(block.getCaption());
+            assertNotNull(block.getCollapsible());
+        }
+    }
+    
+    @Nested
+    @DisplayName("CaptionConfig")
+    class CaptionConfigTest {
+        
+        @Test
+        @DisplayName("should build with all properties")
+        void shouldBuildWithAllProperties() {
+            // Given/When
+            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder()
+                    .required(true)
+                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*")
+                    .minLength(15)
+                    .maxLength(100)
+                    .severity(Severity.ERROR)
+                    .build();
+            
+            // Then
+            assertTrue(config.isRequired());
+            assertNotNull(config.getPattern());
+            assertEquals("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*", config.getPattern().pattern());
+            assertEquals(15, config.getMinLength());
+            assertEquals(100, config.getMaxLength());
+            assertEquals(Severity.ERROR, config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should handle null pattern")
+        void shouldHandleNullPattern() {
+            // Given/When
+            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder()
+                    .required(false)
+                    .pattern(null)
+                    .build();
+            
+            // Then
+            assertNull(config.getPattern());
+        }
+        
+        @Test
+        @DisplayName("should have correct equals and hashCode")
+        void shouldHaveCorrectEqualsAndHashCode() {
+            // Given
+            ExampleBlock.CaptionConfig config1 = ExampleBlock.CaptionConfig.builder()
+                    .required(true)
+                    .pattern("^Example.*")
+                    .minLength(10)
+                    .maxLength(50)
+                    .severity(Severity.WARN)
+                    .build();
+                    
+            ExampleBlock.CaptionConfig config2 = ExampleBlock.CaptionConfig.builder()
+                    .required(true)
+                    .pattern("^Example.*")
+                    .minLength(10)
+                    .maxLength(50)
+                    .severity(Severity.WARN)
+                    .build();
+                    
+            ExampleBlock.CaptionConfig config3 = ExampleBlock.CaptionConfig.builder()
+                    .required(false)
+                    .pattern("^Example.*")
+                    .minLength(10)
+                    .maxLength(50)
+                    .severity(Severity.WARN)
+                    .build();
+            
+            // Then
+            assertEquals(config1, config2);
+            assertEquals(config1.hashCode(), config2.hashCode());
+            assertNotEquals(config1, config3);
+        }
+        
+        @Test
+        @DisplayName("should have meaningful toString")
+        void shouldHaveMeaningfulToString() {
+            // Given
+            ExampleBlock.CaptionConfig config = ExampleBlock.CaptionConfig.builder()
+                    .required(true)
+                    .pattern("^Example.*")
+                    .minLength(10)
+                    .maxLength(50)
+                    .severity(Severity.ERROR)
+                    .build();
+            
+            // When
+            String result = config.toString();
+            
+            // Then
+            assertTrue(result.contains("required=true"));
+            assertTrue(result.contains("pattern=^Example.*"));
+            assertTrue(result.contains("minLength=10"));
+            assertTrue(result.contains("maxLength=50"));
+            assertTrue(result.contains("severity=ERROR"));
+        }
+    }
+    
+    @Nested
+    @DisplayName("CollapsibleConfig")
+    class CollapsibleConfigTest {
+        
+        @Test
+        @DisplayName("should build with all properties")
+        void shouldBuildWithAllProperties() {
+            // Given
+            List<Boolean> allowed = Arrays.asList(true, false);
+            
+            // When
+            ExampleBlock.CollapsibleConfig config = ExampleBlock.CollapsibleConfig.builder()
+                    .required(false)
+                    .allowed(allowed)
+                    .severity(Severity.INFO)
+                    .build();
+            
+            // Then
+            assertFalse(config.isRequired());
+            assertEquals(allowed, config.getAllowed());
+            assertEquals(Severity.INFO, config.getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should have correct equals and hashCode")
+        void shouldHaveCorrectEqualsAndHashCode() {
+            // Given
+            List<Boolean> allowed = Arrays.asList(true, false);
+            
+            ExampleBlock.CollapsibleConfig config1 = ExampleBlock.CollapsibleConfig.builder()
+                    .required(false)
+                    .allowed(allowed)
+                    .severity(Severity.INFO)
+                    .build();
+                    
+            ExampleBlock.CollapsibleConfig config2 = ExampleBlock.CollapsibleConfig.builder()
+                    .required(false)
+                    .allowed(allowed)
+                    .severity(Severity.INFO)
+                    .build();
+                    
+            ExampleBlock.CollapsibleConfig config3 = ExampleBlock.CollapsibleConfig.builder()
+                    .required(true)
+                    .allowed(allowed)
+                    .severity(Severity.INFO)
+                    .build();
+            
+            // Then
+            assertEquals(config1, config2);
+            assertEquals(config1.hashCode(), config2.hashCode());
+            assertNotEquals(config1, config3);
+        }
+        
+        @Test
+        @DisplayName("should have meaningful toString")
+        void shouldHaveMeaningfulToString() {
+            // Given
+            List<Boolean> allowed = Arrays.asList(true, false);
+            ExampleBlock.CollapsibleConfig config = ExampleBlock.CollapsibleConfig.builder()
+                    .required(false)
+                    .allowed(allowed)
+                    .severity(Severity.INFO)
+                    .build();
+            
+            // When
+            String result = config.toString();
+            
+            // Then
+            assertTrue(result.contains("required=false"));
+            assertTrue(result.contains("allowed=[true, false]"));
+            assertTrue(result.contains("severity=INFO"));
+        }
+    }
+    
+    @Test
+    @DisplayName("should have correct equals and hashCode")
+    void shouldHaveCorrectEqualsAndHashCode() {
+        // Given
+        ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder()
+                .required(true)
+                .pattern("^Example.*")
+                .build();
+                
+        ExampleBlock block1 = ExampleBlock.builder()
+                .name("example-1")
+                .severity(Severity.WARN)
+                .caption(caption)
+                .build();
+                
+        ExampleBlock block2 = ExampleBlock.builder()
+                .name("example-1")
+                .severity(Severity.WARN)
+                .caption(caption)
+                .build();
+                
+        ExampleBlock block3 = ExampleBlock.builder()
+                .name("example-2")
+                .severity(Severity.WARN)
+                .caption(caption)
+                .build();
+        
+        // Then
+        assertEquals(block1, block2);
+        assertEquals(block1.hashCode(), block2.hashCode());
+        assertNotEquals(block1, block3);
+    }
+    
+    @Test
+    @DisplayName("should have meaningful toString")
+    void shouldHaveMeaningfulToString() {
+        // Given
+        ExampleBlock.CaptionConfig caption = ExampleBlock.CaptionConfig.builder()
+                .required(true)
+                .pattern("^Example.*")
+                .severity(Severity.ERROR)
+                .build();
+                
+        ExampleBlock.CollapsibleConfig collapsible = ExampleBlock.CollapsibleConfig.builder()
+                .required(false)
+                .allowed(Arrays.asList(true, false))
+                .severity(Severity.INFO)
+                .build();
+                
+        ExampleBlock block = ExampleBlock.builder()
+                .name("example-test")
+                .severity(Severity.WARN)
+                .caption(caption)
+                .collapsible(collapsible)
+                .build();
+        
+        // When
+        String result = block.toString();
+        
+        // Then
+        assertTrue(result.contains("name='example-test'"));
+        assertTrue(result.contains("severity=WARN"));
+        assertTrue(result.contains("caption="));
+        assertTrue(result.contains("collapsible="));
+    }
+}

--- a/src/test/java/com/example/linter/config/loader/ExampleBlockYamlTest.java
+++ b/src/test/java/com/example/linter/config/loader/ExampleBlockYamlTest.java
@@ -1,0 +1,201 @@
+package com.example.linter.config.loader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.ExampleBlock;
+
+@DisplayName("ExampleBlock YAML Loading")
+class ExampleBlockYamlTest {
+    
+    private ConfigurationLoader loader;
+    
+    @BeforeEach
+    void setUp() {
+        loader = new ConfigurationLoader(true); // Skip schema validation for tests
+    }
+    
+    @Test
+    @DisplayName("should load example block with minimal configuration")
+    void shouldLoadExampleBlockWithMinimalConfiguration() throws Exception {
+        // Given
+        String yaml = """
+            document:
+              sections:
+                - name: test-section
+                  min: 1
+                  max: 1
+                  allowedBlocks:
+                    - example:
+                        name: minimal-example
+                        severity: warn
+            """;
+        
+        InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+        
+        // When
+        LinterConfiguration config = loader.loadConfiguration(stream);
+        
+        // Then
+        var section = config.document().sections().get(0);
+        var block = section.allowedBlocks().get(0);
+        
+        assertInstanceOf(ExampleBlock.class, block);
+        ExampleBlock exampleBlock = (ExampleBlock) block;
+        
+        assertEquals("minimal-example", exampleBlock.getName());
+        assertEquals(Severity.WARN, exampleBlock.getSeverity());
+        assertNull(exampleBlock.getCaption());
+        assertNull(exampleBlock.getCollapsible());
+    }
+    
+    @Test
+    @DisplayName("should load example block with caption configuration")
+    void shouldLoadExampleBlockWithCaptionConfiguration() throws Exception {
+        // Given
+        String yaml = """
+            document:
+              sections:
+                - name: test-section
+                  min: 1
+                  max: 1
+                  allowedBlocks:
+                    - example:
+                        name: example-with-caption
+                        severity: warn
+                        caption:
+                          required: true
+                          pattern: "^(Example|Beispiel)\\\\s+\\\\d+\\\\.\\\\d*:.*"
+                          minLength: 15
+                          maxLength: 100
+                          severity: error
+            """;
+        
+        InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+        
+        // When
+        LinterConfiguration config = loader.loadConfiguration(stream);
+        
+        // Then
+        var section = config.document().sections().get(0);
+        var block = section.allowedBlocks().get(0);
+        
+        assertInstanceOf(ExampleBlock.class, block);
+        ExampleBlock exampleBlock = (ExampleBlock) block;
+        
+        assertNotNull(exampleBlock.getCaption());
+        var caption = exampleBlock.getCaption();
+        
+        assertTrue(caption.isRequired());
+        assertNotNull(caption.getPattern());
+        assertEquals("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*", caption.getPattern().pattern());
+        assertEquals(15, caption.getMinLength());
+        assertEquals(100, caption.getMaxLength());
+        assertEquals(Severity.ERROR, caption.getSeverity());
+    }
+    
+    @Test
+    @DisplayName("should load example block with collapsible configuration")
+    void shouldLoadExampleBlockWithCollapsibleConfiguration() throws Exception {
+        // Given
+        String yaml = """
+            document:
+              sections:
+                - name: test-section
+                  min: 1
+                  max: 1
+                  allowedBlocks:
+                    - example:
+                        name: example-with-collapsible
+                        severity: warn
+                        collapsible:
+                          required: false
+                          allowed: [true, false]
+                          severity: info
+            """;
+        
+        InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+        
+        // When
+        LinterConfiguration config = loader.loadConfiguration(stream);
+        
+        // Then
+        var section = config.document().sections().get(0);
+        var block = section.allowedBlocks().get(0);
+        
+        assertInstanceOf(ExampleBlock.class, block);
+        ExampleBlock exampleBlock = (ExampleBlock) block;
+        
+        assertNotNull(exampleBlock.getCollapsible());
+        var collapsible = exampleBlock.getCollapsible();
+        
+        assertFalse(collapsible.isRequired());
+        assertEquals(Arrays.asList(true, false), collapsible.getAllowed());
+        assertEquals(Severity.INFO, collapsible.getSeverity());
+    }
+    
+    @Test
+    @DisplayName("should load example block with full configuration")
+    void shouldLoadExampleBlockWithFullConfiguration() throws Exception {
+        // Given
+        String yaml = """
+            document:
+              sections:
+                - name: test-section
+                  min: 1
+                  max: 1
+                  allowedBlocks:
+                    - example:
+                        name: full-example
+                        severity: warn
+                        occurrence:
+                          min: 0
+                          max: 10
+                        caption:
+                          required: true
+                          pattern: "^Example \\\\d+:.*"
+                          minLength: 10
+                          maxLength: 50
+                          severity: error
+                        collapsible:
+                          required: false
+                          allowed: [true, false]
+                          severity: info
+            """;
+        
+        InputStream stream = new ByteArrayInputStream(yaml.getBytes(StandardCharsets.UTF_8));
+        
+        // When
+        LinterConfiguration config = loader.loadConfiguration(stream);
+        
+        // Then
+        var section = config.document().sections().get(0);
+        var block = section.allowedBlocks().get(0);
+        
+        assertInstanceOf(ExampleBlock.class, block);
+        ExampleBlock exampleBlock = (ExampleBlock) block;
+        
+        assertEquals("full-example", exampleBlock.getName());
+        assertEquals(Severity.WARN, exampleBlock.getSeverity());
+        
+        assertNotNull(exampleBlock.getOccurrence());
+        assertEquals(0, exampleBlock.getOccurrence().min());
+        assertEquals(10, exampleBlock.getOccurrence().max());
+        
+        assertNotNull(exampleBlock.getCaption());
+        assertTrue(exampleBlock.getCaption().isRequired());
+        
+        assertNotNull(exampleBlock.getCollapsible());
+        assertFalse(exampleBlock.getCollapsible().isRequired());
+    }
+}

--- a/src/test/java/com/example/linter/validator/block/ExampleBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/ExampleBlockValidatorTest.java
@@ -1,0 +1,429 @@
+package com.example.linter.validator.block;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.asciidoctor.ast.StructuralNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.ExampleBlock;
+import com.example.linter.validator.ValidationMessage;
+import com.example.linter.validator.SourceLocation;
+
+@DisplayName("ExampleBlockValidator")
+class ExampleBlockValidatorTest {
+    
+    private ExampleBlockValidator validator;
+    private StructuralNode mockNode;
+    private BlockValidationContext mockContext;
+    private SourceLocation mockLocation;
+    
+    @BeforeEach
+    void setUp() {
+        validator = new ExampleBlockValidator();
+        mockNode = mock(StructuralNode.class);
+        mockContext = mock(BlockValidationContext.class);
+        mockLocation = mock(SourceLocation.class);
+        when(mockContext.createLocation(any())).thenReturn(mockLocation);
+    }
+    
+    @Test
+    @DisplayName("should return EXAMPLE as supported type")
+    void shouldReturnExampleAsSupportedType() {
+        assertEquals(BlockType.EXAMPLE, validator.getSupportedType());
+    }
+    
+    @Test
+    @DisplayName("should throw exception for invalid block config type")
+    void shouldThrowExceptionForInvalidBlockConfigType() {
+        // Given
+        var invalidBlock = mock(com.example.linter.config.blocks.Block.class);
+        
+        // When/Then
+        assertThrows(IllegalArgumentException.class, 
+            () -> validator.validate(mockNode, invalidBlock, mockContext));
+    }
+    
+    @Nested
+    @DisplayName("Caption Validation")
+    class CaptionValidation {
+        
+        @Test
+        @DisplayName("should pass when caption is not configured")
+        void shouldPassWhenCaptionIsNotConfigured() {
+            // Given
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertTrue(messages.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should fail when caption is required but missing")
+        void shouldFailWhenCaptionIsRequiredButMissing() {
+            // Given
+            when(mockNode.getTitle()).thenReturn(null);
+            
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
+                    .required(true)
+                    .severity(Severity.ERROR)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .caption(captionConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertEquals(1, messages.size());
+            assertEquals("Example block requires a caption", messages.get(0).getMessage());
+            assertEquals(Severity.ERROR, messages.get(0).getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should pass when caption matches pattern")
+        void shouldPassWhenCaptionMatchesPattern() {
+            // Given
+            when(mockNode.getTitle()).thenReturn("Example 1.2: Basic usage");
+            
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
+                    .required(true)
+                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*")
+                    .minLength(15)
+                    .maxLength(100)
+                    .severity(Severity.ERROR)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .caption(captionConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertTrue(messages.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should fail when caption does not match pattern")
+        void shouldFailWhenCaptionDoesNotMatchPattern() {
+            // Given
+            when(mockNode.getTitle()).thenReturn("Invalid caption format");
+            
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
+                    .pattern("^(Example|Beispiel)\\s+\\d+\\.\\d*:.*")
+                    .severity(Severity.ERROR)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .caption(captionConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertEquals(1, messages.size());
+            assertTrue(messages.get(0).getMessage().contains("does not match required pattern"));
+            assertEquals(Severity.ERROR, messages.get(0).getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should fail when caption is too short")
+        void shouldFailWhenCaptionIsTooShort() {
+            // Given
+            when(mockNode.getTitle()).thenReturn("Short");
+            
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
+                    .minLength(15)
+                    .severity(Severity.WARN)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.ERROR)
+                    .caption(captionConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertEquals(1, messages.size());
+            assertTrue(messages.get(0).getMessage().contains("less than required minimum"));
+            assertEquals(Severity.WARN, messages.get(0).getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should fail when caption is too long")
+        void shouldFailWhenCaptionIsTooLong() {
+            // Given
+            String longCaption = "A".repeat(101);
+            when(mockNode.getTitle()).thenReturn(longCaption);
+            
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
+                    .maxLength(100)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .caption(captionConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertEquals(1, messages.size());
+            assertTrue(messages.get(0).getMessage().contains("exceeds maximum"));
+            assertEquals(Severity.WARN, messages.get(0).getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should use block severity when caption severity is not specified")
+        void shouldUseBlockSeverityWhenCaptionSeverityNotSpecified() {
+            // Given
+            when(mockNode.getTitle()).thenReturn(null);
+            
+            ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
+                    .required(true)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.INFO)
+                    .caption(captionConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertEquals(1, messages.size());
+            assertEquals(Severity.INFO, messages.get(0).getSeverity());
+        }
+    }
+    
+    @Nested
+    @DisplayName("Collapsible Validation")
+    class CollapsibleValidation {
+        
+        @Test
+        @DisplayName("should pass when collapsible is not configured")
+        void shouldPassWhenCollapsibleIsNotConfigured() {
+            // Given
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertTrue(messages.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should fail when collapsible is required but missing")
+        void shouldFailWhenCollapsibleIsRequiredButMissing() {
+            // Given
+            when(mockNode.getAttribute("collapsible-option")).thenReturn(null);
+            when(mockNode.getAttribute("collapsible")).thenReturn(null);
+            
+            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
+                    .required(true)
+                    .severity(Severity.ERROR)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .collapsible(collapsibleConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertEquals(1, messages.size());
+            assertEquals("Example block requires a collapsible attribute", messages.get(0).getMessage());
+            assertEquals(Severity.ERROR, messages.get(0).getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should pass when collapsible value is allowed")
+        void shouldPassWhenCollapsibleValueIsAllowed() {
+            // Given
+            when(mockNode.getAttribute("collapsible-option")).thenReturn(true);
+            
+            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
+                    .allowed(Arrays.asList(true, false))
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .collapsible(collapsibleConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertTrue(messages.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should handle string boolean values")
+        void shouldHandleStringBooleanValues() {
+            // Given
+            when(mockNode.getAttribute("collapsible-option")).thenReturn("true");
+            
+            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
+                    .allowed(Arrays.asList(true, false))
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .collapsible(collapsibleConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertTrue(messages.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should handle alternative string boolean values")
+        void shouldHandleAlternativeStringBooleanValues() {
+            // Given
+            when(mockNode.getAttribute("collapsible")).thenReturn("yes");
+            
+            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
+                    .allowed(Arrays.asList(true, false))
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .collapsible(collapsibleConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertTrue(messages.isEmpty());
+        }
+        
+        @Test
+        @DisplayName("should fail when collapsible value is not allowed")
+        void shouldFailWhenCollapsibleValueIsNotAllowed() {
+            // Given
+            when(mockNode.getAttribute("collapsible-option")).thenReturn("invalid");
+            
+            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
+                    .allowed(Arrays.asList(true, false))
+                    .severity(Severity.INFO)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.WARN)
+                    .collapsible(collapsibleConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertEquals(1, messages.size());
+            assertTrue(messages.get(0).getMessage().contains("is not in allowed values"));
+            assertEquals(Severity.INFO, messages.get(0).getSeverity());
+        }
+        
+        @Test
+        @DisplayName("should use block severity when collapsible severity is not specified")
+        void shouldUseBlockSeverityWhenCollapsibleSeverityNotSpecified() {
+            // Given
+            when(mockNode.getAttribute("collapsible-option")).thenReturn(null);
+            
+            ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
+                    .required(true)
+                    .build();
+                    
+            ExampleBlock block = ExampleBlock.builder()
+                    .name("test")
+                    .severity(Severity.ERROR)
+                    .collapsible(collapsibleConfig)
+                    .build();
+            
+            // When
+            List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+            
+            // Then
+            assertEquals(1, messages.size());
+            assertEquals(Severity.ERROR, messages.get(0).getSeverity());
+        }
+    }
+    
+    @Test
+    @DisplayName("should validate both caption and collapsible")
+    void shouldValidateBothCaptionAndCollapsible() {
+        // Given
+        when(mockNode.getTitle()).thenReturn(null);
+        when(mockNode.getAttribute("collapsible-option")).thenReturn(null);
+        
+        ExampleBlock.CaptionConfig captionConfig = ExampleBlock.CaptionConfig.builder()
+                .required(true)
+                .build();
+                
+        ExampleBlock.CollapsibleConfig collapsibleConfig = ExampleBlock.CollapsibleConfig.builder()
+                .required(true)
+                .build();
+                
+        ExampleBlock block = ExampleBlock.builder()
+                .name("test")
+                .severity(Severity.WARN)
+                .caption(captionConfig)
+                .collapsible(collapsibleConfig)
+                .build();
+        
+        // When
+        List<ValidationMessage> messages = validator.validate(mockNode, block, mockContext);
+        
+        // Then
+        assertEquals(2, messages.size());
+        assertTrue(messages.stream().anyMatch(m -> m.getMessage().contains("caption")));
+        assertTrue(messages.stream().anyMatch(m -> m.getMessage().contains("collapsible")));
+    }
+}


### PR DESCRIPTION
## Summary
- Implements validation for AsciiDoc example blocks (syntax: ====)
- Adds caption validation with pattern, length requirements, and required flag
- Adds collapsible attribute validation with allowed values [true, false]

## Implementation Details
Following the established pattern for block types:
- `ExampleBlock` configuration class with `CaptionConfig` and `CollapsibleConfig`
- `ExampleBlockValidator` implementing severity hierarchy pattern
- JSON Schema definition for configuration validation
- Complete test coverage for all components

## Test Plan
- [x] Unit tests for ExampleBlock configuration
- [x] Unit tests for ExampleBlockValidator
- [x] YAML configuration loading tests
- [x] All existing tests pass
- [x] Maven build succeeds

Closes #56

🤖 Generated with [Claude Code](https://claude.ai/code)