### PR TITLE
Fix IndexOutOfBoundsException in ContextRenderer for short files

### DIFF
--- a/src/main/java/com/example/linter/report/console/ContextRenderer.java
+++ b/src/main/java/com/example/linter/report/console/ContextRenderer.java
@@ -46,8 +46,12 @@ public class ContextRenderer {
         int startLine = Math.max(1, loc.getStartLine() - config.getContextLines());
         int endLine = Math.min(fileLines.size(), loc.getEndLine() + config.getContextLines());
         
+        // Ensure valid bounds for subList
+        int fromIndex = Math.max(0, Math.min(startLine - 1, fileLines.size()));
+        int toIndex = Math.max(fromIndex, Math.min(endLine, fileLines.size()));
+        
         // Extract context lines
-        List<String> contextLines = fileLines.subList(startLine - 1, endLine);
+        List<String> contextLines = fileLines.subList(fromIndex, toIndex);
         
         return new SourceContext(contextLines, startLine, loc);
     }

--- a/src/test/java/com/example/linter/report/console/ContextRendererTest.java
+++ b/src/test/java/com/example/linter/report/console/ContextRendererTest.java
@@ -1,0 +1,161 @@
+package com.example.linter.report.console;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.output.DisplayConfig;
+import com.example.linter.config.Severity;
+import com.example.linter.validator.SourceLocation;
+import com.example.linter.validator.ValidationMessage;
+
+@DisplayName("ContextRenderer")
+class ContextRendererTest {
+    
+    private ContextRenderer renderer;
+    private DisplayConfig displayConfig;
+    
+    @BeforeEach
+    void setUp() {
+        displayConfig = DisplayConfig.builder()
+            .contextLines(2)
+            .useColors(true)
+            .showLineNumbers(true)
+            .maxLineWidth(120)
+            .showHeader(true)
+            .build();
+        renderer = new ContextRenderer(displayConfig);
+    }
+    
+    @Nested
+    @DisplayName("getContext")
+    class GetContext {
+        
+        @Test
+        @DisplayName("should handle short files without throwing exception")
+        void shouldHandleShortFiles() {
+            // Given
+            SourceLocation location = SourceLocation.builder()
+                .filename("test.adoc")
+                .startLine(8)
+                .endLine(8)
+                .startColumn(1)
+                .endColumn(1)
+                .build();
+                
+            ValidationMessage message = ValidationMessage.builder()
+                .severity(Severity.ERROR)
+                .ruleId("test.rule")
+                .message("Test error")
+                .location(location)
+                .contextLines(List.of("Line 1", "Line 2", "Line 3")) // Short file with only 3 lines
+                .build();
+            
+            // When & Then - should not throw exception
+            assertDoesNotThrow(() -> {
+                SourceContext context = renderer.getContext(message);
+                assertNotNull(context);
+            });
+        }
+        
+        @Test
+        @DisplayName("should use provided context lines when available")
+        void shouldUseProvidedContextLines() {
+            // Given
+            List<String> providedLines = List.of("Line 1", "Line 2", "Line 3");
+            SourceLocation location = SourceLocation.builder()
+                .filename("test.adoc")
+                .startLine(2)
+                .endLine(2)
+                .startColumn(1)
+                .endColumn(10)
+                .build();
+                
+            ValidationMessage message = ValidationMessage.builder()
+                .severity(Severity.ERROR)
+                .ruleId("test.rule")
+                .message("Test error")
+                .location(location)
+                .contextLines(providedLines)
+                .build();
+            
+            // When
+            SourceContext context = renderer.getContext(message);
+            
+            // Then
+            assertNotNull(context.getLines());
+            assertEquals(3, context.getLines().size());
+            assertEquals(location, context.getErrorLocation());
+        }
+        
+        @Test
+        @DisplayName("should handle empty file content")
+        void shouldHandleEmptyFileContent() {
+            // Given
+            SourceLocation location = SourceLocation.builder()
+                .filename("empty.adoc")
+                .startLine(1)
+                .endLine(1)
+                .startColumn(1)
+                .endColumn(1)
+                .build();
+                
+            ValidationMessage message = ValidationMessage.builder()
+                .severity(Severity.ERROR)
+                .ruleId("test.rule")
+                .message("Test error")
+                .location(location)
+                .contextLines(List.of()) // Empty context
+                .build();
+            
+            // When
+            SourceContext context = renderer.getContext(message);
+            
+            // Then
+            assertTrue(context.getLines().isEmpty());
+            assertEquals(location, context.getErrorLocation());
+        }
+        
+        @Test
+        @DisplayName("should handle location at end of file")
+        void shouldHandleLocationAtEndOfFile() {
+            // Given
+            List<String> lines = List.of("Line 1", "Line 2", "Line 3", "Line 4", "Line 5");
+            SourceLocation location = SourceLocation.builder()
+                .filename("test.adoc")
+                .startLine(5)
+                .endLine(5)
+                .startColumn(1)
+                .endColumn(10)
+                .build();
+                
+            ValidationMessage message = ValidationMessage.builder()
+                .severity(Severity.ERROR)
+                .ruleId("test.rule")
+                .message("Test error")
+                .location(location)
+                .contextLines(lines)
+                .build();
+            
+            // When
+            SourceContext context = renderer.getContext(message);
+            
+            // Then
+            assertNotNull(context.getLines());
+            assertEquals(5, context.getLines().size());
+            assertEquals(location, context.getErrorLocation());
+        }
+    }
+    
+    @Test
+    @DisplayName("should clear cache")
+    void shouldClearCache() {
+        // When & Then - should not throw exception
+        assertDoesNotThrow(() -> renderer.clearCache());
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed IndexOutOfBoundsException when processing validation errors in short AsciiDoc files
- Added boundary checks to ensure valid array indices in ContextRenderer.getContext()
- Added comprehensive unit tests for edge cases

## Related Issue
Fixes #65

## Changes Made
1. **ContextRenderer.java**: Added proper bounds checking before calling `subList()` to prevent IndexOutOfBoundsException
2. **ContextRendererTest.java**: Added comprehensive unit tests covering:
   - Short files (less lines than requested context)
   - Empty files
   - Files where error is at the end
   - Files with provided context lines

## Test Results
All existing tests pass, and new tests specifically verify the fix works correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)