### PR TITLE
#69 Refactor: Remove 'warning' severity alias and rename DocumentationGeneratorRunner

### DIFF
--- a/docs/linter-config-specification.yaml
+++ b/docs/linter-config-specification.yaml
@@ -30,19 +30,19 @@ document:
         minLength: 5        # Mindestens 5 Zeichen
         maxLength: 50       # Maximal 50 Zeichen
         pattern: "^[A-Z][a-zA-Z\\s\\.]+$"  # Muss mit Großbuchstabe beginnen
-        severity: error     # PFLICHT: error, warning oder info
+        severity: error     # PFLICHT: error, warn oder info
         
       - name: revdate
         order: 3            # Optional: Nach author
         required: true      # Pflichtfeld
         pattern: "^\\d{4}-\\d{2}-\\d{2}$"  # Format: YYYY-MM-DD
-        severity: error     # PFLICHT: error, warning oder info
+        severity: error     # PFLICHT: error, warn oder info
         
       - name: version
         order: 4            # Optional: Nach revdate
         required: true      # Pflichtfeld
         pattern: "^\\d+\\.\\d+(\\.\\d+)?$"  # Format: 1.0 oder 1.0.0
-        severity: error     # PFLICHT: error, warning oder info
+        severity: error     # PFLICHT: error, warn oder info
         
       - name: email
         # Kein order = flexible Position
@@ -55,14 +55,14 @@ document:
         required: false     # Optional
         minLength: 10       # Mindestens 10 Zeichen
         maxLength: 100      # Maximal 100 Zeichen
-        severity: info      # PFLICHT: error, warning oder info
+        severity: info      # PFLICHT: error, warn oder info
         
       - name: keywords
         # Kein order = flexible Position
         required: false     # Optional
         pattern: "^[a-zA-Z0-9,\\s-]+$"  # Komma-separierte Keywords
         maxLength: 200      # Maximal 200 Zeichen
-        severity: info      # PFLICHT: error, warning oder info
+        severity: info      # PFLICHT: error, warn oder info
 
   # === SECTIONS ===
   # Definiert die erlaubte Struktur und Reihenfolge von Dokumentabschnitten
@@ -425,7 +425,7 @@ document:
                     max: 2
                     lines:
                       max: 5         # Kurze Einführung
-                      severity: info # PFLICHT: error, warning oder info
+                      severity: info # PFLICHT: error, warn oder info
                 - listing:
                     min: 1
                     max: 3

--- a/src/main/java/com/example/linter/cli/DocumentationGenerator.java
+++ b/src/main/java/com/example/linter/cli/DocumentationGenerator.java
@@ -20,11 +20,11 @@ import com.example.linter.documentation.VisualizationStyle;
 /**
  * Runner for generating documentation from linter configuration.
  */
-public class DocumentationGeneratorRunner {
+public class DocumentationGenerator {
     
     private final ConfigurationLoader configLoader;
     
-    public DocumentationGeneratorRunner() {
+    public DocumentationGenerator() {
         this.configLoader = new ConfigurationLoader();
     }
     

--- a/src/main/java/com/example/linter/cli/LinterCLI.java
+++ b/src/main/java/com/example/linter/cli/LinterCLI.java
@@ -59,8 +59,8 @@ public class LinterCLI {
                     return 2;
                 }
                 
-                DocumentationGeneratorRunner docRunner = new DocumentationGeneratorRunner();
-                return docRunner.run(cmd);
+                DocumentationGenerator docGenerator = new DocumentationGenerator();
+                return docGenerator.run(cmd);
             }
             
             // For normal validation, input is required

--- a/src/main/java/com/example/linter/config/Severity.java
+++ b/src/main/java/com/example/linter/config/Severity.java
@@ -18,7 +18,7 @@ public enum Severity {
         if (value == null) return null;
         return switch (value.toLowerCase()) {
             case "error" -> ERROR;
-            case "warn", "warning" -> WARN;
+            case "warn" -> WARN;
             case "info" -> INFO;
             default -> throw new IllegalArgumentException("Unknown severity: " + value);
         };


### PR DESCRIPTION
## Summary
- Remove 'warning' as an alias for 'warn' in Severity enum to maintain consistency  
- Rename DocumentationGeneratorRunner to DocumentationGenerator for cleaner naming
- Update documentation files to use 'warn' instead of 'warning'

## Changes
- Modified `Severity.java` to accept only 'warn' (removed 'warning' alias)
- Renamed class from `DocumentationGeneratorRunner` to `DocumentationGenerator`
- Updated all references in `LinterCLI.java`
- Updated documentation in `linter-config-specification.yaml`

## Test Plan
- [x] All existing tests pass (570 tests, 0 failures)
- [x] Build completes successfully
- [x] Documentation generation still works with renamed class

Closes #69

🤖 Generated with [Claude Code](https://claude.ai/code)