### PR TITLE
#71 Clean up unused code and fix compiler warnings

### DIFF
--- a/src/main/java/com/example/linter/cli/CLIOutputHandler.java
+++ b/src/main/java/com/example/linter/cli/CLIOutputHandler.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import com.example.linter.config.output.OutputConfiguration;
 import com.example.linter.config.output.OutputConfigurationLoader;
 import com.example.linter.report.ReportWriter;
 import com.example.linter.validator.ValidationResult;

--- a/src/main/java/com/example/linter/cli/DocumentationGeneratorRunner.java
+++ b/src/main/java/com/example/linter/cli/DocumentationGeneratorRunner.java
@@ -5,7 +5,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/example/linter/cli/FileDiscoveryService.java
+++ b/src/main/java/com/example/linter/cli/FileDiscoveryService.java
@@ -9,10 +9,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
-import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/com/example/linter/config/blocks/AdmonitionBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/AdmonitionBlock.java
@@ -2,9 +2,7 @@ package com.example.linter.config.blocks;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 

--- a/src/main/java/com/example/linter/config/blocks/ExampleBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/ExampleBlock.java
@@ -1,6 +1,5 @@
 package com.example.linter.config.blocks;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;

--- a/src/main/java/com/example/linter/config/blocks/QuoteBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/QuoteBlock.java
@@ -1,13 +1,13 @@
 package com.example.linter.config.blocks;
 
+import java.util.Objects;
+import java.util.regex.Pattern;
+
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-
-import java.util.Objects;
-import java.util.regex.Pattern;
 
 /**
  * Configuration for quote blocks.

--- a/src/main/java/com/example/linter/config/blocks/VideoBlock.java
+++ b/src/main/java/com/example/linter/config/blocks/VideoBlock.java
@@ -1,15 +1,14 @@
 package com.example.linter.config.blocks;
 
+import java.util.Objects;
+import java.util.regex.Pattern;
+
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
-import com.example.linter.config.rule.OccurrenceConfig;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-
-import java.util.Objects;
-import java.util.regex.Pattern;
 
 @JsonDeserialize(builder = VideoBlock.Builder.class)
 public class VideoBlock extends AbstractBlock {

--- a/src/main/java/com/example/linter/config/loader/ConfigurationException.java
+++ b/src/main/java/com/example/linter/config/loader/ConfigurationException.java
@@ -1,12 +1,14 @@
 package com.example.linter.config.loader;
 
 public class ConfigurationException extends RuntimeException {
-    
-    public ConfigurationException(String message) {
-        super(message);
-    }
-    
-    public ConfigurationException(String message, Throwable cause) {
-        super(message, cause);
-    }
+
+	private static final long serialVersionUID = 1L;
+
+	public ConfigurationException(String message) {
+		super(message);
+	}
+
+	public ConfigurationException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/src/main/java/com/example/linter/config/output/OutputConfigurationException.java
+++ b/src/main/java/com/example/linter/config/output/OutputConfigurationException.java
@@ -4,6 +4,7 @@ package com.example.linter.config.output;
  * Exception thrown when output configuration loading or validation fails.
  */
 public class OutputConfigurationException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
     
     public OutputConfigurationException(String message) {
         super(message);

--- a/src/main/java/com/example/linter/config/validation/RuleValidationException.java
+++ b/src/main/java/com/example/linter/config/validation/RuleValidationException.java
@@ -4,12 +4,14 @@ package com.example.linter.config.validation;
  * Exception thrown when user configuration does not match the schema.
  */
 public class RuleValidationException extends RuntimeException {
-    
-    public RuleValidationException(String message) {
-        super(message);
-    }
-    
-    public RuleValidationException(String message, Throwable cause) {
-        super(message, cause);
-    }
+
+	private static final long serialVersionUID = 1L;
+
+	public RuleValidationException(String message) {
+		super(message);
+	}
+
+	public RuleValidationException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/src/main/java/com/example/linter/documentation/AsciiDocRuleGenerator.java
+++ b/src/main/java/com/example/linter/documentation/AsciiDocRuleGenerator.java
@@ -326,14 +326,14 @@ public class AsciiDocRuleGenerator implements RuleDocumentationGenerator {
             return "Beliebig";
         }
         
-        Integer min = block.getOccurrence().min();
-        Integer max = block.getOccurrence().max();
+        int min = block.getOccurrence().min();
+        int max = block.getOccurrence().max();
         
-        if (min != null && max != null) {
+        if (min > 0 && max < Integer.MAX_VALUE) {
             return min + "-" + max;
-        } else if (min != null) {
+        } else if (min > 0) {
             return "Mindestens " + min;
-        } else if (max != null) {
+        } else if (max < Integer.MAX_VALUE) {
             return "Maximal " + max;
         }
         return "Beliebig";

--- a/src/main/java/com/example/linter/documentation/visualizers/BreadcrumbVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/BreadcrumbVisualizer.java
@@ -8,9 +8,9 @@ import com.example.linter.config.DocumentConfiguration;
 import com.example.linter.config.LinterConfiguration;
 import com.example.linter.config.MetadataConfiguration;
 import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.rule.AttributeConfig;
 import com.example.linter.config.rule.SectionConfig;
-import com.example.linter.config.blocks.Block;
 import com.example.linter.documentation.HierarchyVisualizer;
 import com.example.linter.documentation.VisualizationStyle;
 

--- a/src/main/java/com/example/linter/documentation/visualizers/NestedListVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/NestedListVisualizer.java
@@ -118,13 +118,13 @@ public class NestedListVisualizer implements HierarchyVisualizer {
         
         if (block.getOccurrence() != null) {
             writer.print(" (");
-            Integer min = block.getOccurrence().min();
-            Integer max = block.getOccurrence().max();
-            if (min != null && max != null) {
+            int min = block.getOccurrence().min();
+            int max = block.getOccurrence().max();
+            if (min > 0 && max < Integer.MAX_VALUE) {
                 writer.print(min + "-" + max + " Stück");
-            } else if (min != null) {
+            } else if (min > 0) {
                 writer.print("min. " + min + " Stück");
-            } else if (max != null) {
+            } else if (max < Integer.MAX_VALUE) {
                 writer.print("max. " + max + " Stück");
             }
             writer.print(")");

--- a/src/main/java/com/example/linter/documentation/visualizers/NestedListVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/NestedListVisualizer.java
@@ -7,9 +7,9 @@ import com.example.linter.config.DocumentConfiguration;
 import com.example.linter.config.LinterConfiguration;
 import com.example.linter.config.MetadataConfiguration;
 import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.rule.AttributeConfig;
 import com.example.linter.config.rule.SectionConfig;
-import com.example.linter.config.blocks.Block;
 import com.example.linter.documentation.HierarchyVisualizer;
 import com.example.linter.documentation.VisualizationStyle;
 

--- a/src/main/java/com/example/linter/documentation/visualizers/TableVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/TableVisualizer.java
@@ -8,9 +8,9 @@ import com.example.linter.config.DocumentConfiguration;
 import com.example.linter.config.LinterConfiguration;
 import com.example.linter.config.MetadataConfiguration;
 import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.rule.AttributeConfig;
 import com.example.linter.config.rule.SectionConfig;
-import com.example.linter.config.blocks.Block;
 import com.example.linter.documentation.HierarchyVisualizer;
 import com.example.linter.documentation.VisualizationStyle;
 

--- a/src/main/java/com/example/linter/documentation/visualizers/TableVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/TableVisualizer.java
@@ -194,13 +194,13 @@ public class TableVisualizer implements HierarchyVisualizer {
         }
         
         if (block.getOccurrence() != null) {
-            Integer min = block.getOccurrence().min();
-            Integer max = block.getOccurrence().max();
-            if (min != null && max != null) {
+            int min = block.getOccurrence().min();
+            int max = block.getOccurrence().max();
+            if (min > 0 && max < Integer.MAX_VALUE) {
                 desc.add(min + "-" + max + " mal");
-            } else if (min != null) {
+            } else if (min > 0) {
                 desc.add("Min. " + min + " mal");
-            } else if (max != null) {
+            } else if (max < Integer.MAX_VALUE) {
                 desc.add("Max. " + max + " mal");
             }
         }

--- a/src/main/java/com/example/linter/documentation/visualizers/TreeVisualizer.java
+++ b/src/main/java/com/example/linter/documentation/visualizers/TreeVisualizer.java
@@ -6,9 +6,9 @@ import java.util.List;
 import com.example.linter.config.DocumentConfiguration;
 import com.example.linter.config.LinterConfiguration;
 import com.example.linter.config.MetadataConfiguration;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.config.rule.AttributeConfig;
 import com.example.linter.config.rule.SectionConfig;
-import com.example.linter.config.blocks.Block;
 import com.example.linter.documentation.HierarchyVisualizer;
 import com.example.linter.documentation.VisualizationStyle;
 

--- a/src/main/java/com/example/linter/report/ConsoleFormatter.java
+++ b/src/main/java/com/example/linter/report/ConsoleFormatter.java
@@ -9,7 +9,11 @@ import java.util.stream.Collectors;
 
 import com.example.linter.config.output.OutputConfiguration;
 import com.example.linter.config.output.OutputFormat;
-import com.example.linter.report.console.*;
+import com.example.linter.report.console.GroupingEngine;
+import com.example.linter.report.console.MessageGroup;
+import com.example.linter.report.console.MessageGroups;
+import com.example.linter.report.console.MessageRenderer;
+import com.example.linter.report.console.SummaryRenderer;
 import com.example.linter.validator.ValidationMessage;
 import com.example.linter.validator.ValidationResult;
 

--- a/src/main/java/com/example/linter/report/ReportWriter.java
+++ b/src/main/java/com/example/linter/report/ReportWriter.java
@@ -157,10 +157,6 @@ public class ReportWriter {
         }
     }
     
-    private ReportFormatter getFormatter(String format) {
-        return getFormatter(format, null);
-    }
-    
     private ReportFormatter getFormatter(String format, OutputConfiguration outputConfig) {
         String formatName = format != null ? format.toLowerCase() : "console";
         

--- a/src/main/java/com/example/linter/report/console/MessageRenderer.java
+++ b/src/main/java/com/example/linter/report/console/MessageRenderer.java
@@ -4,7 +4,6 @@ import java.io.PrintWriter;
 import java.util.Objects;
 
 import com.example.linter.config.output.OutputConfiguration;
-import com.example.linter.config.output.OutputFormat;
 import com.example.linter.validator.ValidationMessage;
 
 /**

--- a/src/main/java/com/example/linter/validator/BlockValidator.java
+++ b/src/main/java/com/example/linter/validator/BlockValidator.java
@@ -12,7 +12,6 @@ import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.Block;
 import com.example.linter.config.rule.SectionConfig;
 import com.example.linter.validator.block.BlockOccurrenceValidator;
-import com.example.linter.validator.block.BlockOrderValidator;
 import com.example.linter.validator.block.BlockTypeDetector;
 import com.example.linter.validator.block.BlockTypeValidator;
 import com.example.linter.validator.block.BlockValidationContext;
@@ -20,20 +19,18 @@ import com.example.linter.validator.block.BlockValidatorFactory;
 
 /**
  * Main validator for blocks within sections.
- * Orchestrates block type validation, occurrence validation, and order validation.
+ * Orchestrates block type validation and occurrence validation.
  */
 public final class BlockValidator {
     
     private final BlockValidatorFactory validatorFactory;
     private final BlockTypeDetector typeDetector;
     private final BlockOccurrenceValidator occurrenceValidator;
-    private final BlockOrderValidator orderValidator;
     
     public BlockValidator() {
         this.validatorFactory = new BlockValidatorFactory();
         this.typeDetector = new BlockTypeDetector();
         this.occurrenceValidator = new BlockOccurrenceValidator();
-        this.orderValidator = new BlockOrderValidator();
     }
     
     /**

--- a/src/main/java/com/example/linter/validator/Suggestion.java
+++ b/src/main/java/com/example/linter/validator/Suggestion.java
@@ -1,8 +1,8 @@
 package com.example.linter.validator;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.ArrayList;
 
 /**
  * A suggestion for fixing a validation error.

--- a/src/main/java/com/example/linter/validator/block/AdmonitionBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/AdmonitionBlockValidator.java
@@ -1,9 +1,7 @@
 package com.example.linter.validator.block;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.asciidoctor.ast.StructuralNode;
 

--- a/src/main/java/com/example/linter/validator/block/AudioBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/AudioBlockValidator.java
@@ -7,8 +7,8 @@ import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.AudioBlock;
+import com.example.linter.config.blocks.Block;
 import com.example.linter.validator.ValidationMessage;
 
 /**

--- a/src/main/java/com/example/linter/validator/block/ExampleBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/ExampleBlockValidator.java
@@ -2,7 +2,6 @@ package com.example.linter.validator.block;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.asciidoctor.ast.StructuralNode;
 
@@ -10,8 +9,8 @@ import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.ExampleBlock;
-import com.example.linter.validator.ValidationMessage;
 import com.example.linter.validator.SourceLocation;
+import com.example.linter.validator.ValidationMessage;
 
 /**
  * Validator for EXAMPLE blocks.

--- a/src/main/java/com/example/linter/validator/block/ImageBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/ImageBlockValidator.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
-import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.ImageBlock;
 import com.example.linter.validator.ValidationMessage;

--- a/src/main/java/com/example/linter/validator/block/LiteralBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/LiteralBlockValidator.java
@@ -1,7 +1,6 @@
 package com.example.linter.validator.block;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.asciidoctor.ast.StructuralNode;

--- a/src/main/java/com/example/linter/validator/block/ParagraphBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/ParagraphBlockValidator.java
@@ -2,8 +2,6 @@ package com.example.linter.validator.block;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.asciidoctor.ast.StructuralNode;
 
@@ -186,14 +184,6 @@ public final class ParagraphBlockValidator implements BlockTypeValidator {
     
     private List<String> splitIntoSentences(String content) {
         List<String> sentences = new ArrayList<>();
-        
-        // Pattern to match sentence endings: period, exclamation mark, question mark
-        // followed by whitespace or end of string
-        // Handles abbreviations like "e.g.", "i.e.", etc.
-        Pattern sentencePattern = Pattern.compile(
-            "([^.!?]+(?:[.!?](?![.!?])|\\.[a-z]\\.)+[.!?]?)(?:\\s+|$)", 
-            Pattern.CASE_INSENSITIVE | Pattern.DOTALL
-        );
         
         // First, replace newlines with spaces to handle multi-line sentences
         String normalizedContent = content.replaceAll("\\n+", " ").trim();

--- a/src/main/java/com/example/linter/validator/block/QuoteBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/QuoteBlockValidator.java
@@ -1,15 +1,15 @@
 package com.example.linter.validator.block;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.asciidoctor.ast.StructuralNode;
+
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.QuoteBlock;
 import com.example.linter.validator.ValidationMessage;
-import org.asciidoctor.ast.StructuralNode;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Validator for quote blocks.

--- a/src/main/java/com/example/linter/validator/block/VerseBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/VerseBlockValidator.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.asciidoctor.ast.StructuralNode;
 
 import com.example.linter.config.BlockType;
-import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.VerseBlock;
 import com.example.linter.validator.ValidationMessage;

--- a/src/main/java/com/example/linter/validator/block/VideoBlockValidator.java
+++ b/src/main/java/com/example/linter/validator/block/VideoBlockValidator.java
@@ -1,18 +1,18 @@
 package com.example.linter.validator.block;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.asciidoctor.ast.StructuralNode;
+
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.VideoBlock;
 import com.example.linter.validator.ErrorType;
-import com.example.linter.validator.SourceLocation;
 import com.example.linter.validator.Suggestion;
 import com.example.linter.validator.ValidationMessage;
-import org.asciidoctor.ast.StructuralNode;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Validator for video blocks in AsciiDoc documents.

--- a/src/test/java/com/example/linter/cli/CLIOptionsTest.java
+++ b/src/test/java/com/example/linter/cli/CLIOptionsTest.java
@@ -2,7 +2,6 @@ package com.example.linter.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.cli.CommandLine;

--- a/src/test/java/com/example/linter/config/blocks/AdmonitionBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/AdmonitionBlockTest.java
@@ -1,5 +1,13 @@
 package com.example.linter.config.blocks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -9,8 +17,6 @@ import org.junit.jupiter.api.Test;
 
 import com.example.linter.config.Severity;
 import com.example.linter.config.rule.LineConfig;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("AdmonitionBlock Tests")
 class AdmonitionBlockTest {

--- a/src/test/java/com/example/linter/config/blocks/ExampleBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/ExampleBlockTest.java
@@ -1,6 +1,11 @@
 package com.example.linter.config.blocks;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/com/example/linter/config/blocks/LiteralBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/LiteralBlockTest.java
@@ -1,5 +1,13 @@
 package com.example.linter.config.blocks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -10,8 +18,6 @@ import com.example.linter.config.blocks.LiteralBlock.IndentationConfig;
 import com.example.linter.config.blocks.LiteralBlock.LinesConfig;
 import com.example.linter.config.blocks.LiteralBlock.TitleConfig;
 import com.example.linter.config.rule.OccurrenceConfig;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class LiteralBlockTest {
     

--- a/src/test/java/com/example/linter/config/blocks/PassBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/PassBlockTest.java
@@ -1,5 +1,13 @@
 package com.example.linter.config.blocks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -14,8 +22,6 @@ import com.example.linter.config.blocks.PassBlock.ContentConfig;
 import com.example.linter.config.blocks.PassBlock.ReasonConfig;
 import com.example.linter.config.blocks.PassBlock.TypeConfig;
 import com.example.linter.config.rule.OccurrenceConfig;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class PassBlockTest {
     

--- a/src/test/java/com/example/linter/config/blocks/QuoteBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/QuoteBlockTest.java
@@ -1,15 +1,20 @@
 package com.example.linter.config.blocks;
 
-import com.example.linter.config.BlockType;
-import com.example.linter.config.Severity;
-import com.example.linter.config.rule.OccurrenceConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.regex.Pattern;
-
-import static org.junit.jupiter.api.Assertions.*;
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.OccurrenceConfig;
 
 @DisplayName("QuoteBlock Configuration Tests")
 class QuoteBlockTest {

--- a/src/test/java/com/example/linter/config/blocks/SidebarBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/SidebarBlockTest.java
@@ -1,5 +1,11 @@
 package com.example.linter.config.blocks;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -9,8 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("SidebarBlock")
 class SidebarBlockTest {

--- a/src/test/java/com/example/linter/config/blocks/VideoBlockTest.java
+++ b/src/test/java/com/example/linter/config/blocks/VideoBlockTest.java
@@ -1,14 +1,21 @@
 package com.example.linter.config.blocks;
 
-import com.example.linter.config.Severity;
-import com.example.linter.config.rule.OccurrenceConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Pattern;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.regex.Pattern;
-
-import static org.junit.jupiter.api.Assertions.*;
+import com.example.linter.config.Severity;
+import com.example.linter.config.rule.OccurrenceConfig;
 
 @DisplayName("VideoBlock")
 class VideoBlockTest {

--- a/src/test/java/com/example/linter/config/loader/ExampleBlockYamlTest.java
+++ b/src/test/java/com/example/linter/config/loader/ExampleBlockYamlTest.java
@@ -1,6 +1,11 @@
 package com.example.linter.config.loader;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;

--- a/src/test/java/com/example/linter/config/loader/QuoteBlockYamlTest.java
+++ b/src/test/java/com/example/linter/config/loader/QuoteBlockYamlTest.java
@@ -1,19 +1,24 @@
 package com.example.linter.config.loader;
 
-import com.example.linter.config.BlockType;
-import com.example.linter.config.DocumentConfiguration;
-import com.example.linter.config.LinterConfiguration;
-import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.QuoteBlock;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.example.linter.config.BlockType;
+import com.example.linter.config.LinterConfiguration;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.QuoteBlock;
 
 @DisplayName("QuoteBlock YAML Loading Tests")
 class QuoteBlockYamlTest {

--- a/src/test/java/com/example/linter/config/loader/SidebarBlockYamlTest.java
+++ b/src/test/java/com/example/linter/config/loader/SidebarBlockYamlTest.java
@@ -1,5 +1,12 @@
 package com.example.linter.config.loader;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -8,11 +15,9 @@ import org.junit.jupiter.api.Test;
 import com.example.linter.config.DocumentConfiguration;
 import com.example.linter.config.LinterConfiguration;
 import com.example.linter.config.Severity;
-import com.example.linter.config.rule.SectionConfig;
 import com.example.linter.config.blocks.Block;
 import com.example.linter.config.blocks.SidebarBlock;
-
-import static org.junit.jupiter.api.Assertions.*;
+import com.example.linter.config.rule.SectionConfig;
 
 /**
  * Tests for YAML parsing of sidebar block configurations.

--- a/src/test/java/com/example/linter/config/output/OutputConfigurationLoaderTest.java
+++ b/src/test/java/com/example/linter/config/output/OutputConfigurationLoaderTest.java
@@ -1,6 +1,10 @@
 package com.example.linter.config.output;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/test/java/com/example/linter/config/validation/ComprehensiveSchemaValidationTest.java
+++ b/src/test/java/com/example/linter/config/validation/ComprehensiveSchemaValidationTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.example.linter.config.LinterConfiguration;
-import com.example.linter.config.loader.ConfigurationLoader;
 import com.example.linter.config.loader.ConfigurationException;
+import com.example.linter.config.loader.ConfigurationLoader;
 
 /**
  * Comprehensive schema validation tests for all block types.

--- a/src/test/java/com/example/linter/documentation/AsciiDocRuleGeneratorTest.java
+++ b/src/test/java/com/example/linter/documentation/AsciiDocRuleGeneratorTest.java
@@ -9,7 +9,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,10 +19,10 @@ import com.example.linter.config.DocumentConfiguration;
 import com.example.linter.config.LinterConfiguration;
 import com.example.linter.config.MetadataConfiguration;
 import com.example.linter.config.Severity;
-import com.example.linter.config.rule.AttributeConfig;
-import com.example.linter.config.rule.SectionConfig;
-import com.example.linter.config.rule.OccurrenceConfig;
 import com.example.linter.config.blocks.ParagraphBlock;
+import com.example.linter.config.rule.AttributeConfig;
+import com.example.linter.config.rule.OccurrenceConfig;
+import com.example.linter.config.rule.SectionConfig;
 
 @DisplayName("AsciiDocRuleGenerator")
 class AsciiDocRuleGeneratorTest {

--- a/src/test/java/com/example/linter/report/console/ContextRendererTest.java
+++ b/src/test/java/com/example/linter/report/console/ContextRendererTest.java
@@ -1,6 +1,9 @@
 package com.example.linter.report.console;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -9,8 +12,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.example.linter.config.output.DisplayConfig;
 import com.example.linter.config.Severity;
+import com.example.linter.config.output.DisplayConfig;
 import com.example.linter.validator.SourceLocation;
 import com.example.linter.validator.ValidationMessage;
 

--- a/src/test/java/com/example/linter/validator/BlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/BlockValidatorTest.java
@@ -208,10 +208,10 @@ class BlockValidatorTest {
                 .severity(Severity.ERROR)
                 .build();
             
-            OrderConfig orderConfig = OrderConfig.builder()
-                .fixedOrder(Arrays.asList("header", "data"))
-                .severity(Severity.ERROR)
-                .build();
+//            OrderConfig orderConfig = OrderConfig.builder()
+//                .fixedOrder(Arrays.asList("header", "data"))
+//                .severity(Severity.ERROR)
+//                .build();
             
             SectionConfig config = SectionConfig.builder()
                 .name("Section")

--- a/src/test/java/com/example/linter/validator/EnhancedValidationMessageTest.java
+++ b/src/test/java/com/example/linter/validator/EnhancedValidationMessageTest.java
@@ -1,9 +1,13 @@
 package com.example.linter.validator;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/example/linter/validator/block/AdmonitionBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/AdmonitionBlockValidatorTest.java
@@ -1,9 +1,13 @@
 package com.example.linter.validator.block;
 
-import java.nio.file.Path;
-import java.util.HashMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.List;
-import java.util.Map;
 
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.StructuralNode;
@@ -17,9 +21,6 @@ import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.AdmonitionBlock;
 import com.example.linter.config.rule.LineConfig;
 import com.example.linter.validator.ValidationMessage;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @DisplayName("AdmonitionBlockValidator Tests")
 class AdmonitionBlockValidatorTest {

--- a/src/test/java/com/example/linter/validator/block/ExampleBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/ExampleBlockValidatorTest.java
@@ -1,8 +1,11 @@
 package com.example.linter.validator.block;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
@@ -16,8 +19,8 @@ import org.junit.jupiter.api.Test;
 import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.ExampleBlock;
-import com.example.linter.validator.ValidationMessage;
 import com.example.linter.validator.SourceLocation;
+import com.example.linter.validator.ValidationMessage;
 
 @DisplayName("ExampleBlockValidator")
 class ExampleBlockValidatorTest {

--- a/src/test/java/com/example/linter/validator/block/LiteralBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/LiteralBlockValidatorTest.java
@@ -1,9 +1,11 @@
 package com.example.linter.validator.block;
 
-import java.util.Arrays;
-import java.util.HashMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import java.util.List;
-import java.util.Map;
 
 import org.asciidoctor.ast.StructuralNode;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,9 +23,6 @@ import com.example.linter.config.blocks.LiteralBlock.LinesConfig;
 import com.example.linter.config.blocks.LiteralBlock.TitleConfig;
 import com.example.linter.validator.SourceLocation;
 import com.example.linter.validator.ValidationMessage;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class LiteralBlockValidatorTest {
     

--- a/src/test/java/com/example/linter/validator/block/PassBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/PassBlockValidatorTest.java
@@ -1,9 +1,12 @@
 package com.example.linter.validator.block;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.asciidoctor.ast.StructuralNode;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,9 +24,6 @@ import com.example.linter.config.blocks.PassBlock.ReasonConfig;
 import com.example.linter.config.blocks.PassBlock.TypeConfig;
 import com.example.linter.validator.SourceLocation;
 import com.example.linter.validator.ValidationMessage;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 class PassBlockValidatorTest {
     

--- a/src/test/java/com/example/linter/validator/block/QuoteBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/QuoteBlockValidatorTest.java
@@ -1,24 +1,25 @@
 package com.example.linter.validator.block;
 
-import com.example.linter.config.BlockType;
-import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.Block;
-import com.example.linter.config.blocks.QuoteBlock;
-import com.example.linter.validator.ValidationMessage;
-import com.example.linter.validator.SourceLocation;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
 import org.asciidoctor.ast.StructuralNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import static org.mockito.ArgumentMatchers.any;
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.Block;
+import com.example.linter.config.blocks.QuoteBlock;
+import com.example.linter.validator.SourceLocation;
+import com.example.linter.validator.ValidationMessage;
 
 @DisplayName("QuoteBlockValidator Tests")
 class QuoteBlockValidatorTest {

--- a/src/test/java/com/example/linter/validator/block/SidebarBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/SidebarBlockValidatorTest.java
@@ -1,5 +1,9 @@
 package com.example.linter.validator.block;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
 import java.util.List;
 
 import org.asciidoctor.ast.Cursor;
@@ -16,9 +20,6 @@ import com.example.linter.config.BlockType;
 import com.example.linter.config.Severity;
 import com.example.linter.config.blocks.SidebarBlock;
 import com.example.linter.validator.ValidationMessage;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @DisplayName("SidebarBlockValidator")
 class SidebarBlockValidatorTest {

--- a/src/test/java/com/example/linter/validator/block/VideoBlockValidatorTest.java
+++ b/src/test/java/com/example/linter/validator/block/VideoBlockValidatorTest.java
@@ -1,12 +1,13 @@
 package com.example.linter.validator.block;
 
-import com.example.linter.config.BlockType;
-import com.example.linter.config.Severity;
-import com.example.linter.config.blocks.ParagraphBlock;
-import com.example.linter.config.blocks.VideoBlock;
-import com.example.linter.validator.ErrorType;
-import com.example.linter.validator.SourceLocation;
-import com.example.linter.validator.ValidationMessage;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
 import org.asciidoctor.ast.StructuralNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,11 +16,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.any;
+import com.example.linter.config.BlockType;
+import com.example.linter.config.Severity;
+import com.example.linter.config.blocks.ParagraphBlock;
+import com.example.linter.config.blocks.VideoBlock;
+import com.example.linter.validator.ErrorType;
+import com.example.linter.validator.SourceLocation;
+import com.example.linter.validator.ValidationMessage;
 
 @DisplayName("VideoBlockValidator")
 class VideoBlockValidatorTest {


### PR DESCRIPTION
## Summary
- Fixed dead code warnings in documentation visualizers by changing Integer to int for primitive types
- Added missing serialVersionUID to OutputConfigurationException
- Removed unused orderValidator field from BlockValidator
- General code cleanup removing unused imports and variables

## Test plan
- [x] All tests pass (`mvn test`)
- [x] Build completes without warnings (`mvn clean compile`)
- [x] No IDE warnings for unused code

🤖 Generated with [Claude Code](https://claude.ai/code)